### PR TITLE
Stricter validation of article numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,7 @@
 /tests/docs/pod.t
 /tests/innd/artparse.t
 /tests/innd/chan.t
+/tests/lib/artnumber.t
 /tests/lib/asprintf.t
 /tests/lib/buffer.t
 /tests/lib/concat.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -912,6 +912,7 @@ tests/innd/artparse-t.c               Tests for ARTparse in innd
 tests/innd/chan-t.c                   Tests for CHAN functions in innd
 tests/innd/fakeinnd.c                 Provide symbols defined by innd/innd.c
 tests/lib                             Test suite for libinn (Directory)
+tests/lib/artnumber-t.c               Tests for lib/numbers.c
 tests/lib/asprintf-t.c                Tests for lib/asprintf.c
 tests/lib/buffer-t.c                  Tests for lib/buffer.c
 tests/lib/concat-t.c                  Tests for lib/concat.c

--- a/lib/numbers.c
+++ b/lib/numbers.c
@@ -11,13 +11,15 @@
 
 /*
 **  Check if the argument is a valid article number according to RFC 3977,
-**  that is to say it contains from 1 to 16 digits.
+**  that is to say it contains from 1 to 16 digits and must lie in the range
+**  0-2,147,483,647.
 */
 bool
 IsValidArticleNumber(const char *string)
 {
-    int len = 0;
+    int len = 0, digit;
     const unsigned char *p;
+    unsigned long v = 0;
 
     /* Not NULL. */
     if (string == NULL)
@@ -29,6 +31,10 @@ IsValidArticleNumber(const char *string)
         len++;
         if (!isdigit((unsigned char) *p))
             return false;
+        digit = *p - '0';
+        if(v > (0x7FFFFFFFul - digit) / 10)
+            return false;
+        v = 10 * v + digit;
     }
 
     if (len > 0 && len < 17)

--- a/support/mkmanifest
+++ b/support/mkmanifest
@@ -271,6 +271,7 @@ tests/clients/server-list
 tests/docs/pod.t
 tests/innd/artparse.t
 tests/innd/chan.t
+tests/lib/artnumber.t
 tests/lib/asprintf.t
 tests/lib/buffer.t
 tests/lib/concat.t

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ LIBM_LDFLAGS    = '-lm'
 ##  list.  If they need other things compiled, those other things should be
 ##  added to EXTRA.
 
-TESTS	= authprogs/ident.t innd/artparse.t innd/chan.t lib/asprintf.t \
+TESTS	= authprogs/ident.t innd/artparse.t innd/chan.t lib/artnumber.t lib/asprintf.t \
 	lib/buffer.t lib/concat.t lib/conffile.t lib/confparse.t lib/date.t \
 	lib/dispatch.t lib/fdflag.t \
 	lib/getaddrinfo.t lib/getnameinfo.t lib/hash.t \
@@ -87,6 +87,9 @@ innd/artparse.t: innd/artparse-t.o innd/fakeinnd.o tap/basic.o $(INNOBJS)
 
 innd/chan.t: innd/chan-t.o innd/fakeinnd.o tap/basic.o $(INNOBJS)
 	$(LINK) innd/chan-t.o innd/fakeinnd.o tap/basic.o $(INNOBJS) $(INNDLIBS)
+
+lib/artnumber.t: lib/artnumber-t.o tap/basic.o $(LIBINN)
+	$(LINK) lib/artnumber-t.o tap/basic.o $(LIBINN)
 
 lib/asprintf.o: ../lib/asprintf.c
 	$(CC) $(CFLAGS) -DTESTING -c -o $@ ../lib/asprintf.c

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -5,6 +5,7 @@ clients/getlist
 docs/pod
 innd/artparse
 innd/chan
+lib/artnumber
 lib/asprintf
 lib/buffer
 lib/concat

--- a/tests/lib/artnumber-t.c
+++ b/tests/lib/artnumber-t.c
@@ -1,0 +1,68 @@
+/*
+** IsValidArticleNumber & IsValidRange tests
+*/
+
+#define LIBTEST_NEW_FORMAT 1
+
+#include "inn/libinn.h"
+#include "tap/basic.h"
+#include "clibrary.h"
+#include <assert.h>
+
+static void
+testIsValidArticleNumber(void)
+{
+    is_bool(false, IsValidArticleNumber(""), "empty article number");
+    is_bool(false, IsValidArticleNumber(" "), "only whitespace");
+    is_bool(false, IsValidArticleNumber(" 1"), "leading whitespace");
+    is_bool(false, IsValidArticleNumber("1 "), "trailing whitespace");
+    is_bool(false, IsValidArticleNumber("wot"), "only non-digits");
+    is_bool(false, IsValidArticleNumber("wot123"), "leading non-digits");
+    is_bool(false, IsValidArticleNumber("123wot"), "trailing non-digits");
+    is_bool(false, IsValidArticleNumber("00000000000000001"), "too long");
+    is_bool(false, IsValidArticleNumber("2147483648"), "too big");
+    is_bool(false, IsValidArticleNumber("-1"), "negative");
+
+    is_bool(true, IsValidArticleNumber("0"), "zero");
+    is_bool(true, IsValidArticleNumber("1"), "one");
+    is_bool(true, IsValidArticleNumber("2147483647"), "maximum value");
+    is_bool(true, IsValidArticleNumber("0000000000000001"), "maximum length");
+}
+
+/* IsValidRange mutates its argument, so we must wrap it. */
+static int wrap_IsValidRange(const char *str) {
+    char buffer[256];
+    assert(strlen(str) < sizeof buffer);
+    strlcpy(buffer, str, sizeof buffer);
+    return IsValidRange(buffer);
+}
+
+static void
+testIsValidRange(void)
+{
+    is_bool(false, wrap_IsValidRange(""), "empty article range");
+    is_bool(false, wrap_IsValidRange("--"), "two dashes alone");
+    is_bool(false, wrap_IsValidRange("1 - 2"), "forbidden whitespace");
+    is_bool(false, wrap_IsValidRange("1-2-3"), "multiple bounds");
+    is_bool(false, wrap_IsValidRange("1--2"), "two dashes");
+    is_bool(false, wrap_IsValidRange("1-2-"), "excess trailing dash");
+    is_bool(false, wrap_IsValidRange("-1-2"), "excess leading dash");
+
+    is_bool(true, wrap_IsValidRange("-"), "single dash");
+    is_bool(true, wrap_IsValidRange("1-"), "unbounded above");
+    is_bool(true, wrap_IsValidRange("-2147483647"), "unbounded below");
+    is_bool(true, wrap_IsValidRange("2-99"), "fully bounded");
+    is_bool(true, wrap_IsValidRange("99-2"), "reverse bounds"); /* explicitly countenanced by RFC3977. */
+}
+
+
+int
+main(void)
+{
+    plan(14+12);
+
+    testIsValidArticleNumber();
+    testIsValidRange();
+
+    return 0;
+}


### PR DESCRIPTION
This brings the implementation largely in line with RFC3977, and fixes
anomalous behavior when very large article numbers are passed in NNTP
commands, e.g. OVER reduces the article number mod 2^32 and then
returns an unexpected range of articles.

Adds tests for IsValidArticleNumber and IsValidRange.