### PR TITLE
innreport: subtract duplicated articles from rejected volume

### DIFF
--- a/scripts/innreport_inn.pm
+++ b/scripts/innreport_inn.pm
@@ -653,7 +653,7 @@ sub collect($$$$$$) {
                 $innd_rejected{$server} += $rejected;
                 $innd_stored_size{$server} += $accptsize;
                 $innd_duplicated_size{$server} += $dupsize;
-                $innd_rejected_size{$server} += ($rjctsize || 0);
+                $innd_rejected_size{$server} += ($rjctsize - $dupsize || 0);
             }
             return 1;
         }


### PR DESCRIPTION
The innd checkpoint line includes the size of duplicated articles in the rejected volume.
innreport adds up both numbers in totals, average article size and graphs. This is probably only noticeable when running with "wipcheck 0".
resolves #257 
