### PR TITLE
Draft: Run the pynntp tests in the build GitHub Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       # - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
       # CAUTION: Running as root is dangerous.
-      - run: sudo INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
       - run: groups $(whoami)
       - run: sudo chgrp news $RUNNER_WORKSPACE/inn-install/bin/rc.news
       - run: sudo chmod g+x $RUNNER_WORKSPACE/inn-install/bin/rc.news
-      - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news  # start
 
       # CAUTION: Running as root is dangerous.
       # - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       - run: echo -e "local.general 1726983313 usenet\nlocal.test 1726983317 usenet" > $RUNNER_WORKSPACE/inn-install/db/active.times
       - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
       # - run: sudo INN_HOSTNAME=inn.github-action make install
-      - run: sudo -u news INN_HOSTNAME=inn.github-action make install
+      - run: sudo INN_HOSTNAME=inn.github-action make install
       # This fails on:
       # > touch /home/runner/work/inn/inn-install/db/history
       # > chmod 0664 /home/runner/work/inn/inn-install/db/history
@@ -55,6 +55,9 @@ jobs:
       # - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
       # - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
       # - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
+      - run: ls -la $RUNNER_WORKSPACE/inn/site || true  # Useful for debugging
+      - run: cat $RUNNER_WORKSPACE/inn/site/inn.conf || true  # Useful for debugging
       - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
       # CAUTION: Running as root is dangerous.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,9 @@ jobs:
 
     steps:
       - run: env
+      - run: echo $USER $(whoami)
       - run: sudo usermod -aG news $USER
+      - run: sudo usermod -aG news $(whoami)
       - uses: actions/checkout@v4
       - run: sudo -E ci/install
       - run: ./autogen
@@ -59,6 +61,9 @@ jobs:
       - run: sudo chown -R $USER:news $RUNNER_WORKSPACE/inn-install
       - run: ls -la $RUNNER_WORKSPACE/inn/site || true  # Useful for debugging
       - run: cat $RUNNER_WORKSPACE/inn/site/inn.conf || true  # Useful for debugging
+      - run: groups $(whoami)
+      - run: sudo chgrp news $RUNNER_WORKSPACE/inn-install/bin/rc.news
+      - run: sudo chmod g+x $RUNNER_WORKSPACE/inn-install/bin/rc.news
       - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
       # CAUTION: Running as root is dangerous.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,8 @@ jobs:
       - run: touch $RUNNER_WORKSPACE/inn-install/db/history
       - run: echo -e "local.general 1726983313 usenet\nlocal.test 1726983317 usenet" > $RUNNER_WORKSPACE/inn-install/db/active.times
       - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
-      - run: sudo INN_HOSTNAME=inn.github-action make install
+      # - run: sudo INN_HOSTNAME=inn.github-action make install
+      - run: sudo -u news INN_HOSTNAME=inn.github-action make install
       # This fails on:
       # > touch /home/runner/work/inn/inn-install/db/history
       # > chmod 0664 /home/runner/work/inn/inn-install/db/history
@@ -54,10 +55,10 @@ jobs:
       # - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
       # - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
       # - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
-      # - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
       # CAUTION: Running as root is dangerous.
-      - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      # - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,83 @@ jobs:
       C_TAP_VERBOSE: 1
 
     steps:
+      - run: exit 1  # TODO(cclauss): Remove this line!!!
       - name: checkout
         uses: actions/checkout@v4
       - name: install
         run: sudo -E ci/install
       - name: test
         run: ci/test
+
+  pynntp_tests:
+    runs-on: ubuntu-latest
+
+    env:
+      AUTHOR_TESTING: 1
+      C_TAP_VERBOSE: 1
+
+    steps:
+      - run: env
+      - uses: actions/checkout@v4
+      - run: sudo -E ci/install
+      - run: ./autogen
+      - run: ./configure CC="${COMPILER:-gcc}" --prefix=$RUNNER_WORKSPACE/inn-install
+                --with-canlock --with-news-user=news --with-news-group=news --with-openssl
+                --with-perl --with-python --with-sasl --with-zlib  
+      - run: make
+      - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
+      - run: touch $RUNNER_WORKSPACE/inn-install/db/history
+      - run: echo -e "local.general 1726983313 usenet\nlocal.test 1726983317 usenet" > $RUNNER_WORKSPACE/inn-install/db/active.times
+      - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
+      - run: sudo INN_HOSTNAME=inn.github-action make install
+      # This fails on:
+      # > touch /home/runner/work/inn/inn-install/db/history
+      # > chmod 0664 /home/runner/work/inn/inn-install/db/history
+      # > makedbz: cannot chdir to /home/runner/work/inn/inn-install/db: Permission denied
+
+      # - run: sudo -u news make install
+
+      - run: systemctl status inn2 || true
+      - run: env
+      # - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
+      # - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
+      # - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      # - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+
+      # CAUTION: Running as root is dangerous.
+      - run: sudo INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+
+
+
+
+      - run: pwd && ls -la
+      - run: ls -lR /etc 2>/dev/null | grep -E 'inn|news'
+      - run: ls -l /usr/local  # No `news` directory
+      # - run: ls -lR /usr/local/news 2>/dev/null | grep -E 'inn|news' || true
+      # - run: find /etc -name inn.conf 2>/dev/null || true
+      - run: find /home -name inn.conf 2>/dev/null || true
+      # - run: find /usr/local/news -name inn.conf 2>/dev/null || true
+      - run: ls -la $RUNNER_WORKSPACE/inn/site || true
+      - run: cat $RUNNER_WORKSPACE/inn/site/inn.conf || true  # Useful for debugging
+      # - run: cat /usr/local/news/etc/inn.conf || true  # Useful for debugging
+      # - run: ls /etc/systemd/system || true
+      # - run: systemctl --help || true
+      # - run: systemctl list-units --all || true
+      # - run: systemctl list-units --type=service --all || true
+      - run: sudo systemctl enable inn2 || true
+      - run: sudo systemctl start inn2 || true
+      # - run: systemctl show inn2 || true
+      - run: systemctl status inn2 || true
+      # - run: /usr/lib/news/bin/rc.news || true
+      # Run all pynntp tests
+      - run: ls -la
+      - uses: actions/checkout@v4
+        with:
+          repository: greenbender/pynntp
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install --upgrade pip
+      - run: pip install pytest
+      - run: pip install --editable .
+      - run: pytest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,17 +30,18 @@ jobs:
 
     steps:
       - run: env
+      - run: sudo usermod -aG news $USER
       - uses: actions/checkout@v4
       - run: sudo -E ci/install
       - run: ./autogen
       - run: ./configure CC="${COMPILER:-gcc}" --prefix=$RUNNER_WORKSPACE/inn-install
-                --with-canlock --with-news-user=news --with-news-group=news --with-openssl
+                --with-canlock --with-news-user=$USER --with-news-group=news --with-openssl
                 --with-perl --with-python --with-sasl --with-zlib  
       - run: make
       - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
       - run: touch $RUNNER_WORKSPACE/inn-install/db/history
       - run: echo -e "local.general 1726983313 usenet\nlocal.test 1726983317 usenet" > $RUNNER_WORKSPACE/inn-install/db/active.times
-      - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
+      - run: sudo chown -R $USER:news $RUNNER_WORKSPACE/inn-install
       # - run: sudo INN_HOSTNAME=inn.github-action make install
       - run: sudo INN_HOSTNAME=inn.github-action make install
       # This fails on:
@@ -55,10 +56,10 @@ jobs:
       # - run: mkdir -p $RUNNER_WORKSPACE/inn-install/db
       # - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
       # - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
-      - run: sudo chown -R news:news $RUNNER_WORKSPACE/inn-install
+      - run: sudo chown -R $USER:news $RUNNER_WORKSPACE/inn-install
       - run: ls -la $RUNNER_WORKSPACE/inn/site || true  # Useful for debugging
       - run: cat $RUNNER_WORKSPACE/inn/site/inn.conf || true  # Useful for debugging
-      - run: sudo -u news INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
+      - run: INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
       # CAUTION: Running as root is dangerous.
       # - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - run: exit 1  # TODO(cclauss): Remove this line!!!
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: install
         run: sudo -E ci/install
       - name: test
@@ -33,7 +33,7 @@ jobs:
       - run: echo $USER $(whoami)
       - run: sudo usermod -aG news $USER
       - run: sudo usermod -aG news $(whoami)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: sudo -E ci/install
       - run: ./autogen
       - run: ./configure CC="${COMPILER:-gcc}" --prefix=$RUNNER_WORKSPACE/inn-install
@@ -69,9 +69,6 @@ jobs:
       # CAUTION: Running as root is dangerous.
       # - run: sudo su news ; INN_HOSTNAME=inn.github-action $RUNNER_WORKSPACE/inn-install/bin/rc.news start
 
-
-
-
       - run: pwd && ls -la
       - run: ls -lR /etc 2>/dev/null | grep -E 'inn|news'
       - run: ls -l /usr/local  # No `news` directory
@@ -93,10 +90,10 @@ jobs:
       # - run: /usr/lib/news/bin/rc.news || true
       # Run all pynntp tests
       - run: ls -la
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: greenbender/pynntp
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: pip install --upgrade pip


### PR DESCRIPTION
Help needed: After `ci/install` and `ci/test` should the inn server be running so that clients can access it?  If so, what should the `hostname` be?  If not, could it be run in a GitHub Actions service (or other background job) like  `inn-docker` does?

Based on https://github.com/greenbender/inn-docker/actions running these pytests should add ~30 seconds but give contributors rapid visibility to breakage with the Python client.

---

% `pytest`
```
============================= test session starts ==============================
platform linux -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/runner/work/inn/inn
configfile: pyproject.toml
collected 54 items
tests/integration/inn2/test_inn2.py FFxxFFFFFFFFFFFF                     [ 29%]
tests/test_headerdict.py ..........                                      [ 48%]
tests/test_utils.py ..xxx...xxx....xxx.....x..                           [ 96%]
tests/test_yenc.py ..                                                    [100%]
=================================== FAILURES ===================================
[ ... ]
>       with nntp.NNTPClient("localhost") as nntp_client:
[ ... ]
/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/socket.py:850: ConnectionRefusedError
[ ... ]
=========================== short test summary info ============================
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_context_manager - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client_without_ssl - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client_with_ssl - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client_with_ssl_starttls - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_post[local.general] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_post[local.test] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_post[junk] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_list_active[local.general] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_list_active[local.test] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_list_active[junk] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_article[local.general] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_article[local.test] - ConnectionRefusedError: [Errno 111] Connection refused
FAILED tests/integration/inn2/test_inn2.py::test_article[junk] - ConnectionRefusedError: [Errno 111] Connection refused
================== 14 failed, 28 passed, 12 xfailed in 1.32s ===================
```