### PR TITLE
Reduce chance for overflow in ParseTime

### DIFF
--- a/storage/interface.c
+++ b/storage/interface.c
@@ -226,19 +226,19 @@ ParseTime(char *tmbuf)
     startnum = tmbuf;
     while (*tmbuf) {
         if (!isdigit((unsigned char) *tmbuf)) {
-            tmp = atol(startnum);
+            tmp = atoi(startnum);
             switch (*tmbuf) {
             case 'M':
-                ret += tmp * 60 * 60 * 24 * 31;
+                ret += tmp * 60LL * 60 * 24 * 31;
                 break;
             case 'd':
-                ret += tmp * 60 * 60 * 24;
+                ret += tmp * 60LL * 60 * 24;
                 break;
             case 'h':
-                ret += tmp * 60 * 60;
+                ret += tmp * 60LL * 60;
                 break;
             case 'm':
-                ret += tmp * 60;
+                ret += tmp * 60LL;
                 break;
             case 's':
                 ret += tmp;


### PR DESCRIPTION
Without this patch, an input of 802M (months) could surprisingly produce a negative return value.

Use `atoi` to match the type of the `tmp` variable.

This patch was done while reviewing potential year-2038 issues in openSUSE.