### PR TITLE
dbz: Fix NULL innconf deref with mmaped tables

### DIFF
--- a/lib/dbz.c
+++ b/lib/dbz.c
@@ -1560,7 +1560,7 @@ set(searcher *sp, hash_table *tab, void *value)
         memcpy(where, value, tab->reclen);
         debug("set: incore");
         if (tab->incore == INCORE_MMAP) {
-            if (innconf->nfswriter) {
+            if (innconf != NULL && innconf->nfswriter) {
                 inn_msync_page(where, tab->reclen, MS_ASYNC);
             }
             return true;


### PR DESCRIPTION
dbz set() dereferenced innconf->nfswriter unconditionally when writing to an INCORE_MMAP table, but innconf may be NULL (it defaults to NULL and is only populated by innconf_read()).  This segfaulted any caller that opens history for writing without loading innconf first.

The crash surfaced under --enable-tagged-hash because hisv6 forces pag_incore = INCORE_MMAP unconditionally in tagged-hash builds, whereas non-tagged builds only use INCORE_MMAP when the HIS_MMAP flag is set. The lib/bloom-hiswalk and expire/tombstone-hisexpire tests, which open history for writing without setting up innconf,  segfaulted only in tagged-hash builds.

Guard the dereference with a NULL check, matching the idiom already used in other libinn/storage code.  nfswriter defaults to false, so a NULL innconf correctly skips the NFS-writer msync optimization.