### PR TITLE
ovsqlite: honor mmapsize in the direct reader path

### DIFF
--- a/doc/pod/ovsqlite.pod
+++ b/doc/pod/ovsqlite.pod
@@ -75,7 +75,12 @@ The maximum number of bytes of the database file that SQLite will
 memory-map.  When set, SQLite reads data directly from the operating
 system's page cache via mmap instead of copying it into its own page
 cache, which can significantly improve read performance for large
-databases.  A good starting value is the size of the database file
+databases.  When I<walmode> is enabled, B<nnrpd> reader processes honor
+this setting too, which additionally lets them share physical memory
+pages for the same database regions through the operating system's page
+cache.  This is of little benefit on ZFS or others without a unified
+buffer cache, where the mapped pages would simply be cached twice.
+A good starting value is the size of the database file
 or the amount of available memory, whichever is smaller.  For example,
 a value of C<4294967296> allows up to S<4 GB> to be memory-mapped.
 The default value of C<0> disables memory-mapped I/O.

--- a/samples/ovsqlite.conf
+++ b/samples/ovsqlite.conf
@@ -13,8 +13,13 @@
 # The maximum number of bytes of the database file that SQLite will
 # memory-map.  When set, SQLite reads data via mmap instead of copying
 # into its own page cache, which can improve read performance for large
-# databases.  A good value is the database file size or available memory,
-# whichever is smaller.  Set to 0 (the default) to disable.
+# databases.  When WAL mode is enabled, nnrpd readers honor this setting
+# too, which additionally lets them share physical memory pages for the
+# same database regions through the operating system's page cache.
+# This is of little benefit on ZFS or others without a unified buffer
+# cache, where the mapped pages would be cached twice.
+# A good value is the database file size or available memory, whichever is
+# smaller.  Set to 0 (the default) to disable.
 #mmapsize:              0
 
 # WAL mode: if true, use SQLite's Write-Ahead Logging journal mode

--- a/storage/ovsqlite/ovsqlite.c
+++ b/storage/ovsqlite/ovsqlite.c
@@ -246,6 +246,7 @@ direct_open(void)
     char *journal_mode = NULL;
     bool use_wal = false;
     unsigned long reader_cachesize = 2000; /* default 2 MB */
+    unsigned long mmapsize = 0;
     int version;
     int compress_flag;
     char sqltext[64];
@@ -265,6 +266,7 @@ direct_open(void)
         config_param_boolean(top, "walmode", &use_wal);
         config_param_unsigned_number(top, "readercachesize",
                                      &reader_cachesize);
+        config_param_unsigned_number(top, "mmapsize", &mmapsize);
         config_free(top);
     }
     if (!use_wal)
@@ -319,6 +321,20 @@ direct_open(void)
         status = sqlite3_exec(read_connection, sqltext, 0, NULL, &errmsg);
         if (status != SQLITE_OK) {
             warn("ovsqlite: cannot set reader cache size: %s", errmsg);
+            sqlite3_free(errmsg);
+        }
+    }
+
+    /* Set mmap size.  Memory-mapping the database lets multiple nnrpd reader
+     * processes share the same physical pages through the operating system's
+     * page cache, reducing total memory use.  This is of little benefit on
+     * ZFS or others without a unified buffer cache, where the mapped pages
+     * would simply be cached twice. */
+    if (mmapsize) {
+        snprintf(sqltext, sizeof sqltext, "pragma mmap_size = %lu;", mmapsize);
+        status = sqlite3_exec(read_connection, sqltext, 0, NULL, &errmsg);
+        if (status != SQLITE_OK) {
+            warn("ovsqlite: cannot set reader mmap size: %s", errmsg);
             sqlite3_free(errmsg);
         }
     }


### PR DESCRIPTION
The mmapsize parameter was only applied by ovsqlite-server.  When WAL mode is enabled, nnrpd readers open the database directly via direct_open(), bypassing the server, so they never set pragma mmap_size.

Read mmapsize in direct_open() and apply it to the read connection, mirroring the server.  Besides the read-performance benefit, memory- mapping lets multiple nnrpd readers share the same physical pages through the OS page cache.  Document the caveat that this helps little on ZFS or other filesystems without a unified buffer cache, where the mapped pages would be cached twice.