### PR TITLE
Update GitHub Actions checkout from v4 to v 6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: install
         run: sudo -E ci/install
       - name: test


### PR DESCRIPTION
https://github.com/actions/checkout/releases is currently v6.0.2

Why: Stop building on EOL versions of Node.js.

Fixes: Annotation on https://github.com/InterNetNews/inn/actions/runs/26530786871/job/78146587295
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information, see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners

Like: https://github.com/InterNetNews/inn/pulls?q=is%3Apr+label%3Adependencies