### PR TITLE
ovsqlite: enable WAL mode by default

### DIFF
--- a/doc/pod/ovsqlite.pod
+++ b/doc/pod/ovsqlite.pod
@@ -88,7 +88,7 @@ The default value of C<0> disables memory-mapped I/O.
 =item I<walmode>
 
 If this parameter is true, ovsqlite will use SQLite's WAL (Write-Ahead
-Logging) journal mode instead of the default PERSIST mode.  WAL mode
+Logging) journal mode instead of PERSIST mode.  WAL mode
 allows concurrent readers and writers without blocking, which significantly
 improves read performance when multiple B<nnrpd> processes access the
 overview database simultaneously.  It also sets C<synchronous> to
@@ -98,10 +98,10 @@ On shutdown, the WAL is checkpointed back into the main database file
 and truncated.
 
 B<Note:> WAL mode requires shared-memory support and does not work on
-network filesystems such as NFS.  Do not enable this parameter if
+network filesystems such as NFS.  Disable this parameter if
 I<pathoverview> is on a network filesystem.
 
-The default value is false.
+The default value is true.
 
 =item I<readercachesize>
 

--- a/samples/ovsqlite.conf
+++ b/samples/ovsqlite.conf
@@ -23,14 +23,14 @@
 #mmapsize:              0
 
 # WAL mode: if true, use SQLite's Write-Ahead Logging journal mode
-# instead of the default PERSIST mode.  WAL mode allows concurrent
+# instead of PERSIST mode.  WAL mode allows concurrent
 # readers and writers without blocking, improving read performance
 # when multiple nnrpd processes access the overview database
 # simultaneously.  Also sets synchronous to NORMAL, which is safe
 # with WAL and reduces unnecessary fsync overhead.
 # Note: WAL mode does not work on network filesystems such as NFS.
-# The default value is false.
-#walmode:               false
+# The default value is true.
+#walmode:               true
 
 # The SQLite database page size in bytes.
 # Must be a power of 2, minimum 512, maximum 65536.

--- a/storage/ovsqlite/ovsqlite-server.c
+++ b/storage/ovsqlite/ovsqlite-server.c
@@ -119,7 +119,7 @@ static sqlite3 *connection;
 static sql_main_t sql_main;
 
 static bool use_compression;
-static bool use_wal;
+static bool use_wal = true;
 static unsigned long pagesize;
 static unsigned long cachesize;
 static unsigned long mmapsize;

--- a/storage/ovsqlite/ovsqlite.c
+++ b/storage/ovsqlite/ovsqlite.c
@@ -244,7 +244,7 @@ direct_open(void)
     int status;
     char *errmsg;
     char *journal_mode = NULL;
-    bool use_wal = false;
+    bool use_wal = true;
     unsigned long reader_cachesize = 2000; /* default 2 MB */
     unsigned long mmapsize = 0;
     int version;


### PR DESCRIPTION
Mostly a suggestion for -current/2.8.

The main hazard is NFS if inn+nnrpd is not **exclusively** run on one mount consumer.. we could possibly add some wrapper around statfs to try and detect it on common platforms.  I would imagine this setup is not common anymore, and would be slow?