### PR TITLE
hissqlite: batch writes during a HIS_INCORE bulk rebuild

### DIFF
--- a/doc/pod/hissqlite.pod
+++ b/doc/pod/hissqlite.pod
@@ -119,7 +119,9 @@ To convert an existing C<hisv6> history into a hissqlite database without
 losing remembered entries or exact timestamps, use B<hissqlite-convert>;
 see hissqlite-convert(8).  Alternatively, you can rebuild the history from
 the article spool with B<makehistory>, though a from-spool rebuild cannot
-reconstruct remembered Message-IDs.
+reconstruct remembered Message-IDs.  Both bulk-load in large batched
+transactions, substantially faster than B<innd>'s steady-state
+one-commit-per-article write path.
 
 =head1 RUNNING
 

--- a/doc/pod/makehistory.pod
+++ b/doc/pod/makehistory.pod
@@ -30,10 +30,13 @@ the malformed article will just be skipped.
 
 When the C<hissqlite> history method is configured, B<makehistory> writes the
 new history into a hissqlite database just as it does for C<hisv6>, and the
-makedbz(8) step above does not apply.  A from-spool rebuild cannot recover
-I<remembered> Message-IDs, so to migrate an existing C<hisv6> history into
-hissqlite without losing them, use hissqlite-convert(8) instead.  See
-hissqlite(5).
+makedbz(8) step above does not apply.  It commits the writes in large batched
+transactions rather than one per article, which makes the rebuild
+substantially faster; this relies on B<makehistory> being the only history
+writer, which its use already requires (see the B<-a> flag description).  A
+from-spool rebuild cannot recover I<remembered> Message-IDs, so to migrate an
+existing C<hisv6> history into hissqlite without losing them, use
+hissqlite-convert(8) instead.  See hissqlite(5).
 
 =head1 OVERVIEW REBUILD
 

--- a/history/hissqlite/hissqlite-main.sql
+++ b/history/hissqlite/hissqlite-main.sql
@@ -19,12 +19,13 @@ pragma foreign_keys = off;
 -- per-connection page cache is affordable; mmap lets reads come from the
 -- shared OS page cache and keeps the random-MD5 B-tree hot.
 
--- Writes are NOT batched: each statement autocommits (one implicit transaction
--- per write).  Under synchronous=NORMAL a commit is a buffered WAL append, not
--- an fsync, so there is no fsync cost to amortise; batching would only hold
--- the write lock across the batch and starve the other writer (expire) in the
--- two-writer model.  Batching is reserved for the offline bulk load
--- (hissqlite-convert.c).  See hissqlite.c.
+-- Steady-state writes are NOT batched: each statement autocommits (one
+-- implicit transaction per write).  Under synchronous=NORMAL a commit is a
+-- buffered WAL append, not an fsync, so there is no fsync cost to amortise;
+-- batching would only hold the write lock across the batch and starve the
+-- other writer (expire) in the two-writer model.  Batching is reserved for
+-- sole-writer bulk loads: the HIS_INCORE rebuild hint (makehistory) and the
+-- offline converter (hissqlite-convert.c).  See hissqlite.c.
 
 -- HISlookup: Message-ID -> token.  A row with token IS NULL (remembered)
 -- returns found=true with an empty token; ARTopenbyid treats TOKEN_EMPTY as

--- a/history/hissqlite/hissqlite-private.h
+++ b/history/hissqlite/hissqlite-private.h
@@ -36,6 +36,11 @@
    long expire does not pin the WAL. */
 #define HISSQLITE_EXPIRE_BATCH    10000
 
+/* HIS_INCORE (a bulk rebuild, makehistory) commits writes in transactions of
+   this many rows instead of one each; matches hissqlite-convert's
+   COMMIT_EVERY.  See the batch_* helpers in hissqlite.c. */
+#define HISSQLITE_BULK_BATCH      50000
+
 /* Fallback values for the inn.conf tunables (hissqlitepagesize,
    hissqlitecachesize, hissqlitemmapsize, hissqlitereadercachesize), used when
    inn.conf has not been read -- offline tools and unit tests that open history
@@ -54,9 +59,13 @@ struct hissqlite {
     int flags; /* HIS_RDONLY / HIS_RDWR / HIS_CREAT / ... */
 
     /* Writer side (NULL for a pure read-only direct reader).  Writes
-       autocommit -- there is no batching state (see hissqlite.c). */
+       autocommit unless the handle was opened HIS_INCORE, the bulk-rebuild
+       hint, which enables transaction batching (see hissqlite.c). */
     hissqlite_main_t main;
-    int wal_pages; /* WAL frame count, updated by the wal_hook. */
+    int wal_pages;        /* WAL frame count, updated by the wal_hook. */
+    size_t batch_size;    /* writes per transaction; 0 = autocommit. */
+    size_t batch_pending; /* writes in the currently open batch. */
+    bool batch_open;      /* an explicit batch transaction is open. */
 
     /* Reader side (used when opened HIS_RDONLY in WAL mode). */
     hissqlite_read_t read;

--- a/history/hissqlite/hissqlite.c
+++ b/history/hissqlite/hissqlite.c
@@ -74,18 +74,69 @@ copy_blob(struct hissqlite *h, sqlite3_stmt *stmt, int col, void *dst,
 }
 
 /*
-**  Writes are NOT batched: each HISwrite/HISremember/HISreplace autocommits
-**  (one implicit transaction per statement).  With synchronous=NORMAL a commit
-**  is a buffered WAL append, not an fsync, so there is no fsync cost to
-**  amortise; batching would buy only a little WAL overhead, at the price of
-**  holding the write lock across the batch.  Holding the lock is exactly wrong
-**  for the two-writer model (innd + a separate expire process): a batch
-**  would starve the other writer.  Autocommit holds the lock for a single
-**  statement, so innd and expire interleave cleanly, and there is no open
-**  transaction to leave dangling on error or to wrap the expire scan.
-**  Batching only makes sense for the single-writer, offline bulk load -- see
-**  hissqlite-convert.c.
+**  Steady-state writes are NOT batched: each HISwrite/HISremember/HISreplace
+**  autocommits (one implicit transaction per statement).  With
+**  synchronous=NORMAL a commit is a buffered WAL append, not an fsync, so
+**  there is no fsync cost to amortise; batching would hold the write lock
+**  across the batch, which is exactly wrong for the two-writer model (innd +
+**  a separate expire process).  The lock hold of an open batch is not the
+**  time to write N rows but the wall-clock time until N articles arrive, so
+**  at low traffic even a small batch could starve expire past its
+**  busy_timeout.  Autocommit holds the lock for a single statement, so innd
+**  and expire interleave cleanly, and there is no open transaction to leave
+**  dangling on error.
+**
+**  Bulk loading is the exception: committing per row costs throughput
+**  (the per-transaction WAL append + wal-index update dominates a random-key
+**  load).  The history API already has a bulk-rebuild hint for exactly this:
+**  HIS_INCORE, which makehistory passes and which hisv6 honors by building
+**  the whole dbz index in core and flushing at close,  sole writer assumed,
+**  durability deferred, a crash means rerunning the rebuild.  hissqlite
+**  translates the same hint into its own terms: HISwrite runs in explicit
+**  transactions of HISSQLITE_BULK_BATCH rows.  The batch commits when full,
+**  on HISsync and on HISclose, so every write that returned true is
+**  committed by close.
 */
+static bool
+batch_commit(struct hissqlite *h)
+{
+    if (!h->batch_open)
+        return true;
+    h->batch_open = false;
+    h->batch_pending = 0;
+    if (sqlite3_exec(h->db, "commit", NULL, NULL, NULL) != SQLITE_OK) {
+        /* The batch's writes are lost; make that loud, then roll back so the
+           connection is not left inside a wedged transaction. */
+        hissqlite_seterror(h, "batch commit");
+        sqlite3_exec(h->db, "rollback", NULL, NULL, NULL);
+        return false;
+    }
+    return true;
+}
+
+static void
+batch_begin(struct hissqlite *h)
+{
+    if (h->batch_size == 0 || h->batch_open)
+        return;
+    /* On failure no transaction is open, so the write below simply
+       autocommits: safe degradation, and the write path reports any real
+       database error itself. */
+    if (sqlite3_exec(h->db, "begin", NULL, NULL, NULL) == SQLITE_OK) {
+        h->batch_open = true;
+        h->batch_pending = 0;
+    }
+}
+
+static bool
+batch_advance(struct hissqlite *h)
+{
+    if (!h->batch_open)
+        return true;
+    if (++h->batch_pending < h->batch_size)
+        return true;
+    return batch_commit(h);
+}
 
 /*
 **  Track the WAL frame count so HISsync can decide when to checkpoint.
@@ -327,6 +378,11 @@ hissqlite_doopen(struct hissqlite *h)
     sqlite3_exec(h->db, pragma, NULL, NULL, NULL);
     snprintf(pragma, sizeof(pragma), "pragma mmap_size = %lu;", mmapsize);
     sqlite3_exec(h->db, pragma, NULL, NULL, NULL);
+
+    /* Bulk rebuild (makehistory): batch the writes; see the batch_* helpers
+       above. */
+    if (h->flags & HIS_INCORE)
+        h->batch_size = HISSQLITE_BULK_BATCH;
     return true;
 
 fail:
@@ -367,6 +423,7 @@ bool
 hissqlite_sync(void *history)
 {
     struct hissqlite *h = history;
+    bool ok = true;
 
     /* HISsync is deliberately NOT a durability barrier, matching dbz:
        hisv6_sync does fflush(3) + msync(MS_ASYNC), neither of which waits for
@@ -378,10 +435,16 @@ hissqlite_sync(void *history)
        be synchronous=FULL, a possible future knob, not an fsync here.)  innd
        calls HISsync on a timer, so it is simply the convenient place to keep
        the WAL bounded: once it has grown past the threshold, do a non-blocking
-       PASSIVE checkpoint. */
-    if (!h->direct_reader && h->wal_pages >= HISSQLITE_WAL_CKPT_PAGES)
-        hissqlite_wal_passive(h);
-    return true;
+       PASSIVE checkpoint.
+
+       Under HISCTLS_WRITEBATCH there IS something buffered: commit the open
+       batch so a bulk loader that calls HISsync gets its writes flushed. */
+    if (!h->direct_reader) {
+        ok = batch_commit(h);
+        if (h->wal_pages >= HISSQLITE_WAL_CKPT_PAGES)
+            hissqlite_wal_passive(h);
+    }
+    return ok;
 }
 
 bool
@@ -408,6 +471,10 @@ hissqlite_close(void *history)
     if (!h->direct_reader) {
         int log = 0, ckpt = 0;
 
+        /* Commit any open bulk-ingest batch so every HISwrite that returned
+           true is in the database before the final checkpoint. */
+        if (!batch_commit(h))
+            ok = false;
         if (sqlite3_wal_checkpoint_v2(h->db, NULL, SQLITE_CHECKPOINT_PASSIVE,
                                       &log, &ckpt)
                 == SQLITE_OK
@@ -491,6 +558,7 @@ hissqlite_write(void *history, const char *key, time_t arrived, time_t posted,
     sqlite3_stmt *stmt = h->main.write;
     bool ok;
 
+    batch_begin(h);
     bind_key(stmt, key);
     sqlite3_bind_int64(stmt, 2, (sqlite3_int64) arrived);
     sqlite3_bind_int64(stmt, 3, (sqlite3_int64) posted);
@@ -509,6 +577,11 @@ hissqlite_write(void *history, const char *key, time_t arrived, time_t posted,
                      concat("hissqlite: duplicate message-id, write ignored: ",
                             key, (char *) NULL));
     sqlite3_reset(stmt);
+    /* After the sqlite3_changes() check: a batch COMMIT must not slip between
+       the INSERT and that read.  A failed write leaves the batch open; its
+       earlier, successful writes commit on the next flush. */
+    if (ok && !batch_advance(h))
+        ok = false;
     return ok;
 }
 

--- a/tests/lib/hissqlite-t.c
+++ b/tests/lib/hissqlite-t.c
@@ -108,7 +108,7 @@ main(void)
     struct walkcount wc;
     bool has_token;
 
-    test_init(27);
+    test_init(32);
 
     strlcpy(tmpdir, "hissqlite-XXXXXX", sizeof(tmpdir));
     if (mkdtemp(tmpdir) == NULL)
@@ -380,6 +380,91 @@ main(void)
         ok(27, kept);
         if (eh != NULL)
             HISclose(eh);
+    }
+
+    /* bulk write batching: HIS_INCORE (the rebuild hint makehistory passes)
+       makes writes commit in transactions of BULK_BATCH rows.  Writes inside
+       an open batch are deferred (invisible to a WAL direct reader) until a
+       commit: on batch full, on HISsync, and on close. */
+#    define BULK_BATCH 50000 /* must match HISSQLITE_BULK_BATCH */
+    {
+        char bpath[160];
+        struct history *bw, *br;
+        TOKEN bt;
+        unsigned long n;
+        char msgid[64];
+
+        snprintf(bpath, sizeof(bpath), "%s/batch", tmpdir);
+        bw = HISopen(bpath, "hissqlite", HIS_CREAT | HIS_RDWR | HIS_INCORE);
+        if (bw == NULL)
+            bail("can't create bulk hissqlite history");
+        memset(&bt, 0, sizeof(bt));
+        bt.type = 1;
+
+        /* 5 writes: the batch is far from full, so it is still open and a
+           WAL direct reader must not see them yet. */
+        for (n = 0; n < 5; n++) {
+            snprintf(msgid, sizeof(msgid), "<batch-%lu@test>", n);
+            if (!HISwrite(bw, msgid, BASE, BASE, 0, &bt))
+                bail("batched HISwrite failed: %s", HISerror(bw));
+        }
+        br = HISopen(bpath, "hissqlite", HIS_RDONLY);
+        ok(28, br != NULL && !HIScheck(br, "<batch-0@test>"));
+
+        /* HISsync commits the open batch; the same reader now sees them. */
+        ok(29, HISsync(bw) && br != NULL && HIScheck(br, "<batch-0@test>")
+                   && HIScheck(br, "<batch-4@test>"));
+
+        /* BULK_BATCH + 3 more writes: one batch fills and commits on its own
+           (its last row, BULK_BATCH+4, becomes visible), three stay pending
+           in the next batch (BULK_BATCH+5..+7, invisible). */
+        for (n = 5; n < 5 + BULK_BATCH + 3; n++) {
+            snprintf(msgid, sizeof(msgid), "<batch-%lu@test>", n);
+            if (!HISwrite(bw, msgid, BASE, BASE, 0, &bt))
+                bail("batched HISwrite failed: %s", HISerror(bw));
+        }
+        {
+            bool committed, pending_hidden;
+
+            snprintf(msgid, sizeof(msgid), "<batch-%d@test>", BULK_BATCH + 4);
+            committed = br != NULL && HIScheck(br, msgid);
+            snprintf(msgid, sizeof(msgid), "<batch-%d@test>", BULK_BATCH + 7);
+            pending_hidden = br != NULL && !HIScheck(br, msgid);
+            ok(30, committed && pending_hidden);
+        }
+        if (br != NULL)
+            HISclose(br);
+
+        /* Close flushes the pending tail; everything written is present. */
+        if (!HISclose(bw))
+            bail("batched HISclose failed");
+        br = HISopen(bpath, "hissqlite", HIS_RDONLY);
+        snprintf(msgid, sizeof(msgid), "<batch-%d@test>", BULK_BATCH + 7);
+        ok(31, br != NULL && HIScheck(br, "<batch-0@test>")
+                   && HIScheck(br, msgid));
+        if (br != NULL)
+            HISclose(br);
+    }
+
+    /* Without HIS_INCORE, writes autocommit: immediately visible to a direct
+       reader with no sync -- the steady-state two-writer invariant. */
+    {
+        char apath[160];
+        struct history *aw, *ar;
+        TOKEN at;
+
+        snprintf(apath, sizeof(apath), "%s/autocommit", tmpdir);
+        aw = HISopen(apath, "hissqlite", HIS_CREAT | HIS_RDWR);
+        memset(&at, 0, sizeof(at));
+        at.type = 1;
+        if (aw != NULL)
+            HISwrite(aw, "<auto@test>", BASE, BASE, 0, &at);
+        ar = HISopen(apath, "hissqlite", HIS_RDONLY);
+        ok(32, aw != NULL && ar != NULL && HIScheck(ar, "<auto@test>"));
+        if (ar != NULL)
+            HISclose(ar);
+        if (aw != NULL)
+            HISclose(aw);
     }
 
     {

--- a/tests/lib/history-bench.c
+++ b/tests/lib/history-bench.c
@@ -80,6 +80,7 @@ struct bench_config {
     uint64_t entries;
     uint64_t random_lookups;
     uint64_t sync_every;
+    bool bulk;
     const char *root;
     bool keep;
     const char **methods;
@@ -146,12 +147,15 @@ usage(int status)
     FILE *out;
 
     out = status == 0 ? stdout : stderr;
-    fprintf(out, "usage: history-bench [-k] [-d dir] [-n entries] "
+    fprintf(out, "usage: history-bench [-Bk] [-d dir] [-n entries] "
                  "[-r random-lookups] [-s sync-every] [method ...]\n");
     fprintf(out, "\n");
     fprintf(out, "Default: -n 100M -r 1M -s 10K hisv6 hissqlite\n");
     fprintf(out, "Counts accept K, M, and G decimal suffixes.\n");
     fprintf(out, "Use -s 0 to disable periodic HISsync during writes.\n");
+    fprintf(out, "-B opens the writer as a bulk rebuild (HIS_INCORE), as\n");
+    fprintf(out, "makehistory does; combine with -s 0 for the pure bulk "
+                 "path.\n");
     fprintf(out, "Benchmark data is removed unless -k is given.\n");
     exit(status);
 }
@@ -295,12 +299,17 @@ remove_tree(const char *path)
 }
 
 static struct history *
-create_history(const char *method, const char *histpath, uint64_t entries)
+create_history(const char *method, const char *histpath, uint64_t entries,
+               bool bulk)
 {
     struct history *h;
     size_t npairs;
+    int flags = HIS_CREAT | HIS_RDWR | (bulk ? HIS_INCORE : HIS_INCORE_HINT);
 
-    h = HISopen(NULL, method, HIS_CREAT | HIS_RDWR | HIS_INCORE_HINT);
+    /* -B swaps innd's steady-state open for makehistory's bulk-rebuild open
+       (HIS_INCORE): hisv6 builds the dbz index in core, hissqlite batches
+       the writes into large transactions. */
+    h = HISopen(NULL, method, flags);
     if (h == NULL)
         return NULL;
     npairs = (size_t) entries;
@@ -359,7 +368,7 @@ benchmark_method(const struct bench_config *config, const char *method,
     fprintf(stderr, "%s create/write %llu entries at %s\n", method,
             (unsigned long long) config->entries, histpath);
     start = now_seconds();
-    h = create_history(method, histpath, config->entries);
+    h = create_history(method, histpath, config->entries, config->bulk);
     if (h == NULL) {
         fprintf(stderr, "%s skipped: %s\n", method,
                 HISerror(h) != NULL ? HISerror(h) : "method unavailable");
@@ -578,6 +587,8 @@ main(int argc, char **argv)
             usage(0);
         } else if (strcmp(argv[i], "-k") == 0) {
             config.keep = true;
+        } else if (strcmp(argv[i], "-B") == 0) {
+            config.bulk = true;
         } else if (strcmp(argv[i], "-n") == 0) {
             if (++i >= argc)
                 usage(1);


### PR DESCRIPTION
Reuse HIS_INCORE, which makehistory passes and which hisv6 used for sole writer rebuilds.

hissqlite's writes autocommit (one implicit transaction per HISwrite where nnd and the in-place expire interleave on the WAL write lock without starving each other using this contract).

That per-transaction cost dominates bulk loading though: makehistory rebuilds 2-3x faster in my benchmarking with this similar to hissqlite-convert which also uses similar batch logic and reasoning.