### PR TITLE
hissqlite: Report remembered entries as not found in HISlookup

### DIFF
--- a/history/hissqlite/hissqlite-main.sql
+++ b/history/hissqlite/hissqlite-main.sql
@@ -26,9 +26,9 @@ pragma foreign_keys = off;
 -- two-writer model.  Batching is reserved for the offline bulk load
 -- (hissqlite-convert.c).  See hissqlite.c.
 
--- HISlookup: Message-ID -> token.  A row with token IS NULL (remembered)
--- returns found=true with an empty token; ARTopenbyid treats TOKEN_EMPTY as
--- "no article".
+-- HISlookup: Message-ID -> token.  A row with token IS NULL (remembered) is
+-- reported as not found, matching hisv6: HISlookup means "have the article";
+-- HIScheck is the existence test that also counts remembered entries.
 -- .lookup
 select arrived, posted, expires, token
     from hist

--- a/history/hissqlite/hissqlite.c
+++ b/history/hissqlite/hissqlite.c
@@ -437,7 +437,13 @@ hissqlite_lookup(void *history, const char *key, time_t *arrived,
 
     bind_key(stmt, key);
     status = sqlite3_step(stmt);
-    if (status == SQLITE_ROW) {
+    if (status == SQLITE_ROW
+        && sqlite3_column_type(stmt, 3) != SQLITE_NULL) {
+        /* A remembered (token IS NULL) row falls through as not-found:
+           HISlookup means "have the article", matching hisv6, which returns
+           true only for a line carrying a token so callers like innd's
+           cancel path and grephistory never see a token-less hit.  HIScheck
+           is the existence test that also counts remembered entries. */
         found = true;
         if (arrived != NULL)
             *arrived = (time_t) sqlite3_column_int64(stmt, 0);
@@ -445,19 +451,14 @@ hissqlite_lookup(void *history, const char *key, time_t *arrived,
             *posted = (time_t) sqlite3_column_int64(stmt, 1);
         if (expires != NULL)
             *expires = (time_t) sqlite3_column_int64(stmt, 2);
-        if (token != NULL) {
-            if (sqlite3_column_type(stmt, 3) == SQLITE_NULL) {
-                /* Remembered entry: found, but no article. */
-                memset(token, 0, sizeof(TOKEN));
-                token->type = TOKEN_EMPTY;
-            } else if (!copy_blob(h, stmt, 3, token, sizeof(TOKEN),
-                                  "corrupt token blob in lookup")) {
-                /* Wrong-length token = corruption.  Treat as a lookup failure
-                   (reported above) rather than masking it as a no-article. */
-                found = false;
-            }
+        if (token != NULL
+            && !copy_blob(h, stmt, 3, token, sizeof(TOKEN),
+                          "corrupt token blob in lookup")) {
+            /* Wrong-length token = corruption.  Treat as a lookup failure
+               (reported above) rather than masking it as a no-article. */
+            found = false;
         }
-    } else if (status != SQLITE_DONE) {
+    } else if (status != SQLITE_ROW && status != SQLITE_DONE) {
         hissqlite_seterror(h, "lookup");
     }
     sqlite3_reset(stmt);

--- a/tests/lib/hissqlite-convert-t.c
+++ b/tests/lib/hissqlite-convert-t.c
@@ -155,16 +155,14 @@ main(void)
     ok(2, reals_ok); /* real tokens and timestamps round-trip */
 
     {
-        TOKEN g1, g2;
         bool f1, f2;
 
-        memset(&g1, 0xff, sizeof(g1));
-        memset(&g2, 0xff, sizeof(g2));
-        /* Remembered entries are found but carry no token (TOKEN_EMPTY). */
-        f1 = HISlookup(h, "<m1@conv>", NULL, NULL, NULL, &g1)
-             && g1.type == TOKEN_EMPTY;
-        f2 = HISlookup(h, "<m2@conv>", NULL, NULL, NULL, &g2)
-             && g2.type == TOKEN_EMPTY;
+        /* Remembered entries are known to HIScheck (refused on re-offer) but
+           not found by HISlookup (no article), matching hisv6. */
+        f1 = HIScheck(h, "<m1@conv>")
+             && !HISlookup(h, "<m1@conv>", NULL, NULL, NULL, NULL);
+        f2 = HIScheck(h, "<m2@conv>")
+             && !HISlookup(h, "<m2@conv>", NULL, NULL, NULL, NULL);
         remembered_ok = f1 && f2;
     }
     ok(3, remembered_ok); /* remembered entries survived the migration */

--- a/tests/lib/hissqlite-t.c
+++ b/tests/lib/hissqlite-t.c
@@ -79,7 +79,9 @@ decide_keep_all(void *cookie UNUSED, time_t arrived UNUSED,
     return true;
 }
 
-/* Does HISlookup find this msgid, and (optionally) does it carry a token? */
+/* Does HISlookup find this msgid, and (optionally) does it carry a token?
+   HISlookup only reports token-bearing entries (as hisv6 does), so found
+   implies has_token; the flag is kept so assertions read explicitly. */
 static bool
 present_with_token(struct history *h, unsigned long n, bool *has_token,
                    TOKEN *out)
@@ -96,6 +98,20 @@ present_with_token(struct history *h, unsigned long n, bool *has_token,
         *out = token;
     free(msgid);
     return found;
+}
+
+/* Is this msgid a remembered entry: known to HIScheck (so it is refused on
+   re-offer) but not found by HISlookup (no article to fetch), matching the
+   hisv6 contract for token-less history lines? */
+static bool
+remembered(struct history *h, unsigned long n)
+{
+    char *msgid = make_msgid(n);
+    bool r;
+
+    r = HIScheck(h, msgid) && !HISlookup(h, msgid, NULL, NULL, NULL, NULL);
+    free(msgid);
+    return r;
 }
 
 int
@@ -159,7 +175,8 @@ main(void)
         free(m_abs);
     }
 
-    /* lookup: real -> token round-trips; remembered -> empty token */
+    /* lookup: real -> token round-trips; remembered -> not found (hisv6
+       parity: only HIScheck reports remembered entries) */
     {
         char *m = make_msgid(5);
         time_t arrived = 0, posted = 0, expires = -1;
@@ -169,8 +186,8 @@ main(void)
                   && memcmp(t2.token, token.token, sizeof(token.token)) == 0);
         free(m);
     }
-    ok(9, present_with_token(h, N_TOKEN + 2, &has_token, NULL) && !has_token);
-    ok(10, !present_with_token(h, 99999, NULL, NULL));
+    ok(9, remembered(h, N_TOKEN + 2));
+    ok(10, !present_with_token(h, 99999, NULL, NULL) && !remembered(h, 99999));
 
     /* walk (before mutations): total and token counts */
     wc.total = wc.with_token = 0;
@@ -194,7 +211,7 @@ main(void)
     {
         char *m = make_msgid(1); /* real -> remembered (NULL token) */
         HISreplace(h, m, BASE + 1, BASE + 1, 0, NULL);
-        ok(14, present_with_token(h, 1, &has_token, NULL) && !has_token);
+        ok(14, remembered(h, 1));
         free(m);
     }
 
@@ -204,11 +221,9 @@ main(void)
                      decide_drop_old));
     /* #10 (arrived BASE+10 < cutoff) -> now remembered; #90 still a token */
     {
-        bool r10 = present_with_token(h, 10, &has_token, NULL);
-        bool t10 = has_token;
-        bool r90 = present_with_token(h, 90, &has_token, NULL);
-        bool t90 = has_token;
-        ok(16, r10 && !t10 && r90 && t90);
+        bool r10 = remembered(h, 10);
+        bool t90 = present_with_token(h, 90, &has_token, NULL) && has_token;
+        ok(16, r10 && t90);
     }
 
     /* expire pass 2: remember-delete past the threshold */


### PR DESCRIPTION
hisv6_lookup returns true only for a history line carrying a storage token, so no HISlookup caller ever sees a token-less hit.  hissqlite instead returned found=true with TOKEN_EMPTY for a remembered (token IS NULL) row, which leaked into callers that are not prepared for it.

Match the hisv6 contract: HISlookup means "have the article" and a remembered row is reported as not found; HIScheck remains the existence test that also counts remembered entries, so re-offers are still refused.  Adjust the tests accordingly.