### PR TITLE
hissqlite: Initialize a fresh database at install

### DIFF
--- a/doc/pod/hissqlite.pod
+++ b/doc/pod/hissqlite.pod
@@ -46,6 +46,12 @@ named by the I<pathdb> parameter with a F<.sqlite> suffix appended
 (by default, F<history.sqlite> in I<pathdb>).  After changing I<hismethod>,
 migrate or rebuild your history (see L</MIGRATION>) and restart INN.
 
+To start with an empty history database on a fresh server, run
+B<makehistory> once: on an empty spool, it simply creates an empty
+F<history.sqlite> (C<make install> does this when I<hismethod> is already
+set to C<hissqlite>).  Do not create the file by hand; B<innd> requires an
+initialized database and will refuse to start on an empty file.
+
 The following F<inn.conf> parameters tune the database; their defaults suit
 most sites.
 

--- a/doc/pod/install.pod
+++ b/doc/pod/install.pod
@@ -1587,7 +1587,8 @@ standalone.  If you don't want these groups to be visible to clients,
 do I<not> delete them; simply hide them in F<readers.conf>.  C<to> must also
 exist as a newsgroup if you have I<mergetogroups> set in F<inn.conf>.
 
-Next, you need to create an empty F<history> database.  To do this, type:
+Next, you need to create an empty F<history> database.  With the default
+C<hisv6> history method, type:
 
     cd <pathdb in inn.conf>
     touch history
@@ -1605,9 +1606,14 @@ This initial size does not limit the number of articles the news server will
 accept.  It will just get slower when that size is exceeded, until the next
 run of B<news.daily> which will appropriately resize it.
 
+If I<hismethod> is set to C<hissqlite> in F<inn.conf>, run B<makehistory>
+(with no arguments) instead: on an empty spool, it simply creates an empty
+F<history.sqlite> database in I<pathdb>.  Do not create the file by hand
+with C<touch>, and no pre-sizing is needed; the database grows by itself.
+
 (Note that if you install INN with C<make install>, you do not need to
 run these commands: the installation takes care of creating the
-F<history> database.)
+history database for the configured I<hismethod>.)
 
 When it finishes, make sure the file permissions are correct on all
 the files you've just created:

--- a/site/Makefile
+++ b/site/Makefile
@@ -150,18 +150,33 @@ $D$(PATH_ACTIVE_TIMES):
 	    chgrp $(RUNASGROUP) $@ ; \
 	fi
 	chmod $(FILEMODE) $@
+##  With hismethod set to hissqlite, the empty database is created by running
+##  makehistory once (instant on an empty spool); the hisv6 history text file
+##  is not touched, so this recipe reruns on later installs and the .sqlite
+##  existence check keeps it a no-op.  innconfval is only run for a real
+##  install ($D empty), where the installed binaries and inn.conf exist; a
+##  DESTDIR (packaging) install takes the historical path and leaves database
+##  initialization to the package's post-install.
 $D$(PATH_HISTORY):
-	touch $@
 	@ME=`$(WHOAMI)` ; \
-	if [ x"$$ME" = xroot ] ; then \
-	    chown $(RUNASUSER) $@ ; \
-	    chgrp $(RUNASGROUP) $@ ; \
-	fi
-	chmod $(FILEMODE) $@
-	@ME=`$(WHOAMI)` ; \
-	if [ -z "$D" ] ; then \
-	    if [ x"$$ME" = xroot ] || [ x"$$ME" = x"$(RUNASUSER)" ] ; then \
-	        $(PATHBIN)/makedbz -i -o ; \
+	if [ -z "$D" ] \
+	   && [ x"`$(PATHBIN)/innconfval hismethod`" = xhissqlite ] ; then \
+	    if [ ! -f "$(PATH_HISTORY).sqlite" ] ; then \
+	        if [ x"$$ME" = xroot ] || [ x"$$ME" = x"$(RUNASUSER)" ] ; then \
+	            $(PATHBIN)/makehistory ; \
+	        fi ; \
+	    fi ; \
+	else \
+	    touch $@ ; \
+	    if [ x"$$ME" = xroot ] ; then \
+	        chown $(RUNASUSER) $@ ; \
+	        chgrp $(RUNASGROUP) $@ ; \
+	    fi ; \
+	    chmod $(FILEMODE) $@ ; \
+	    if [ -z "$D" ] ; then \
+	        if [ x"$$ME" = xroot ] || [ x"$$ME" = x"$(RUNASUSER)" ] ; then \
+	            $(PATHBIN)/makedbz -i -o ; \
+	        fi ; \
 	    fi ; \
 	fi
 


### PR DESCRIPTION
innd deliberately opens the history without HIS_CREAT (a missing database at startup is more likely a mount failure than a fresh install, and auto-creating an empty history would re-accept everything), so initialization must happen beforehand.  "make install" only knew the hisv6 procedure (touch history + makedbz -i -o), which with hismethod set to hissqlite leaves a stray empty hisv6 database and no .sqlite, and innd then refuses to start.

The initializer is makehistory with no arguments: it opens the history with HIS_CREAT, and on an empty spool that simply creates an initialized empty database (the makedbz -i -o equivalent; verified, and the result opens through the WAL direct-reader path).  A bare "touch history.sqlite" is not sufficient: a zero-byte file has no schema and is not in WAL mode, and both innd and the readers refuse it cleanly.

site/Makefile now branches the history-creation recipe on the configured hismethod: for hissqlite it runs makehistory once, keyed on history.sqlite being absent so reinstalls stay no-ops; the hisv6 path is unchanged, and DESTDIR (packaging) installs take the historical path since the installed binaries and inn.conf are not available to query.  Document the manual procedure in INSTALL next to the makedbz instructions and in hissqlite(5).