### PR TITLE
Add SQLite database statistics to utilities

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -994,6 +994,7 @@ tests/lib/headers-t.c                 Tests for lib/headers.c
 tests/lib/hex-t.c                     Tests for lib/hex.c
 tests/lib/hissqlite-convert-t.c       Tests for the hissqlite-convert tool
 tests/lib/hissqlite-t.c               Tests for the hissqlite history method
+tests/lib/hissqlite-util.t            Smoke tests for hissqlite-util
 tests/lib/history-bench.c             Benchmark for the history backends
 tests/lib/inet_aton-t.c               Tests for lib/inet_aton.c
 tests/lib/inet_ntoa-t.c               Tests for lib/inet_ntoa.c

--- a/doc/pod/hissqlite-util.pod
+++ b/doc/pod/hissqlite-util.pod
@@ -4,7 +4,7 @@ hissqlite-util - History manipulation utility for hissqlite
 
 =head1 SYNOPSIS
 
-B<hissqlite-util> [B<-AcdhV>] [B<-p> I<path>]
+B<hissqlite-util> [B<-AcdhsV>] [B<-p> I<path>]
 
 =head1 DESCRIPTION
 
@@ -12,7 +12,7 @@ B<hissqlite-util> is an administrative interface to the hissqlite history
 method for INN.  It only works on hissqlite history databases, not on any
 other type of INN history.  It allows the administrator to audit the
 database for problems, dump its contents, and report entry counts and the
-schema version.
+schema version.  It can also report database storage utilization.
 
 All of its actions are read-only, so it is safe to run while INN is running.
 B<hissqlite-util> opens the database directly; because B<innd> holds the
@@ -65,6 +65,24 @@ Print a usage message and exit.
 Act on the F<history.sqlite> database in I<path> instead of the default
 I<pathhistory> directory from F<inn.conf>.
 
+=item B<-s>
+
+Print database storage and history entry statistics.  The report contains
+the SQLite and schema versions, journal and auto-vacuum modes, page usage,
+database and journal file sizes, total, real and remembered entry counts,
+the number of real entries with an explicit expiration (I<expires> greater
+than zero; zero or NULL means no article-level expiry), and the arrival-time
+range.  It remains available when B<innd> is not running.
+
+The database-derived values are collected from one consistent read snapshot.
+Logical size is the page count multiplied by the page size.  Non-freelist
+page capacity is an estimate based on SQLite's page accounting, not a measure
+of how full each page is.  Freelist pages can be reused by later writes or
+recovered with a full C<VACUUM>.  File sizes are point-in-time values and may
+change while B<innd> or another process is writing.  Files that do not
+currently exist, such as a WAL or rollback journal, have a reported size of
+zero.
+
 =item B<-V>
 
 Print the version of this tool and the database schema version.
@@ -80,6 +98,10 @@ Audit the history database for problems:
 Print entry counts for a database in F</news/db>:
 
     hissqlite-util -c -p /news/db
+
+Print storage and entry statistics:
+
+    hissqlite-util -s
 
 =head1 HISTORY
 

--- a/doc/pod/hissqlite.pod
+++ b/doc/pod/hissqlite.pod
@@ -145,6 +145,8 @@ waits at most briefly.  (B<hissqlite-convert> is a one-time migration tool
 that reads a I<separate> source history, which must not be written while it
 runs; see hissqlite-convert(8).)
 
+C<hissqlite-util -s> reports database storage and entry statistics.
+
 =head1 EXPIRATION
 
 B<expire> runs against the live database in place: real articles past their

--- a/doc/pod/news.pod
+++ b/doc/pod/news.pod
@@ -44,6 +44,17 @@ L<Upgrading from 2.6 to 2.7>.
 
 =item *
 
+A new B<-s> option in B<hissqlite-util> reports SQLite storage utilization,
+history entry counts and file sizes.
+
+=item *
+
+A new B<-s> option in B<ovsqlite-util> reports SQLite storage utilization,
+database and journal file sizes, and active, deleted and total overview
+record counts.
+
+=item *
+
 A new history storage method based on SQLite has been added, named
 C<hissqlite>, selectable instead of C<hisv6> via the I<hismethod> parameter
 in F<inn.conf> when INN is built with SQLite support.  It is accompanied

--- a/doc/pod/ovsqlite-util.pod
+++ b/doc/pod/ovsqlite-util.pod
@@ -6,7 +6,7 @@ ovsqlite-util - Overview manipulation utility for ovsqlite
 
 =head1 SYNOPSIS
 
-B<ovsqlite-util> [B<-AFghioO>] [B<-a> I<article>] [B<-n> I<newsgroup>]
+B<ovsqlite-util> [B<-AFghioOs>] [B<-a> I<article>] [B<-n> I<newsgroup>]
 [B<-p> I<path>]
 
 =head1 DESCRIPTION
@@ -64,7 +64,7 @@ in the group.  Passing C<-> for I<article> is therefore equivalent to not
 using the B<-a> option at all.
 
 Only useful in combination with the B<-g>, B<-o> and B<-O> options to dump
-overview information.
+overview information.  It cannot be combined with B<-s>.
 
 =item B<-A>
 
@@ -116,7 +116,8 @@ not given, the entire master index will be dumped.
 =item B<-n> I<newsgroup>
 
 Specify the newsgroup on which to act, required for the B<-g>, B<-o>, and
-B<-O> options, and optional for the B<-i> option.
+B<-O> options, and optional for the B<-i> option.  It cannot be combined
+with B<-s>.
 
 =item B<-o>
 
@@ -151,6 +152,23 @@ dump to the information for a single article or a range of article numbers.
 Act on the overview database rooted in I<path>, overriding the overview
 path specified in the I<pathoverview> parameter in F<inn.conf>.
 
+=item B<-s>
+
+Print database storage and overview record statistics.  The report contains
+the SQLite and schema versions, journal and auto-vacuum modes, compression
+status, page usage, database and journal file sizes, and counts of active and
+deleted newsgroups, their articles, and any orphaned article records.  It
+remains available when B<ovsqlite-server> is not running.
+
+Database-derived values are collected from one consistent read snapshot.
+The logical database size is the page count multiplied by the page size.
+Non-freelist page capacity is an estimate derived from SQLite's page
+accounting, not a measure of how full each page is.  Freelist pages can be
+reused by later writes or recovered with a full C<VACUUM>.  File sizes are
+point-in-time values and may change while the server is writing.  Files that
+do not currently exist, such as a WAL or rollback journal, have a reported
+size of zero.
+
 =back
 
 =head1 EXAMPLES
@@ -175,6 +193,10 @@ Dump the overview information for articles 45 and higher in example.test:
 Audit the entire overview database for any problems:
 
     ovsqlite-util -A
+
+Print storage and record statistics:
+
+    ovsqlite-util -s
 
 =head1 HISTORY
 

--- a/history/hissqlite/hissqlite-util.in
+++ b/history/hissqlite/hissqlite-util.in
@@ -14,7 +14,7 @@ use POSIX qw(strftime);
 $0 =~ s!.*/!!;
 
 # Version of this tool.
-my $VERSION = "1.0";
+my $VERSION = "1.1";
 
 # Bail out if the needed DBI Perl module is not installed.
 eval {
@@ -29,7 +29,7 @@ eval {
 my $dbfile = "history.sqlite";
 
 my $usage = "Usage:
-  $0 [-AcdhV] [-p path]
+  $0 [-AcdhsV] [-p path]
 
 Options:
   -A             Audit the history database for problems, and report them to
@@ -40,6 +40,7 @@ Options:
   -h             Print this help message.
   -p path        Read $dbfile database file in path directory instead of
                  default \$INN::Config::pathhistory directory.
+  -s             Print database storage and history entry statistics.
   -V             Print the version of this tool and the database schema
                  version.
 ";
@@ -50,7 +51,7 @@ sub HELP_MESSAGE {
 }
 
 my %opt;
-getopts("AcdhVp:", \%opt) || die $usage;
+getopts("AcdhsVp:", \%opt) || die $usage;
 
 HELP_MESSAGE() if defined($opt{'h'});
 
@@ -58,13 +59,19 @@ my $modes = 0;
 $modes++ if defined($opt{'A'});
 $modes++ if defined($opt{'c'});
 $modes++ if defined($opt{'d'});
+$modes++ if defined($opt{'s'});
 $modes++ if defined($opt{'V'});
 
 die "Only one action allowed at the same time\n\n$usage"
   if $modes > 1;
 
-my $dbdir = $opt{'p'} || $INN::Config::pathhistory;
-my $datasource = "dbi:SQLite:dbname=$dbdir/$dbfile";
+my $dbdir;
+{
+    no warnings 'once';
+    $dbdir = $opt{'p'} || $INN::Config::pathhistory;
+}
+my $dbpath = "$dbdir/$dbfile";
+my $datasource = "dbi:SQLite:dbname=$dbpath";
 
 # All implemented modes are read-only, so open the database read-only.
 # SQLITE_OPEN_READONLY is 0x00000001.
@@ -95,6 +102,8 @@ if (defined($opt{'V'})) {
     count_entries();
 } elsif (defined($opt{'d'})) {
     dump_history();
+} elsif (defined($opt{'s'})) {
+    dump_statistics();
 } else {
     # Default action: audit.
     audit_history();
@@ -112,16 +121,21 @@ sub get_version {
     return $version;
 }
 
-# Return a list of (total, real, remembered) entry counts.
+# Return a list of (total, real, remembered, explicitly expiring, earliest
+# arrival, latest arrival).  Compute them in one table scan; callers that only
+# need the first values can ignore the remainder.
 sub get_counts {
-    my ($total) = $dbh->selectrow_array("select count(*) from hist;");
-    my ($real)
-      = $dbh->selectrow_array(
-          "select count(*) from hist" . " where token is not null;");
-    my ($remembered)
-      = $dbh->selectrow_array(
-          "select count(*) from hist" . " where token is null;");
-    return ($total, $real, $remembered);
+    return $dbh->selectrow_array(
+        q{
+            select count(*),
+                   coalesce(sum(token is not null), 0),
+                   coalesce(sum(token is null), 0),
+                   coalesce(sum(token is not null and expires > 0), 0),
+                   min(arrived),
+                   max(arrived)
+                from hist;
+        },
+    );
 }
 
 # Print the tool version and the database schema version (-V option).
@@ -170,6 +184,92 @@ sub dump_history {
     }
 }
 
+# Return the size of a file, or 0 if the file does not exist.
+sub file_size {
+    my $path = shift;
+    my $size = -s $path;
+    return defined($size) ? $size : 0;
+}
+
+# Print database storage and entry statistics (-s).
+sub dump_statistics {
+    # DBD::SQLite's begin_work uses BEGIN IMMEDIATE, which requests a write
+    # lock.  Start a deferred transaction explicitly for this read-only
+    # snapshot.
+    $dbh->do("begin transaction;");
+    my ($sqlite_version)
+      = $dbh->selectrow_array("select sqlite_version();");
+    my $schema_version = get_version();
+    my ($journal_mode) = $dbh->selectrow_array("pragma journal_mode;");
+    my ($auto_vacuum) = $dbh->selectrow_array("pragma auto_vacuum;");
+    my ($page_size) = $dbh->selectrow_array("pragma page_size;");
+    my ($page_count) = $dbh->selectrow_array("pragma page_count;");
+    my ($freelist_count) = $dbh->selectrow_array("pragma freelist_count;");
+    my (
+        $total,               $real,
+        $remembered,          $explicit_expiration,
+        $minarrived,          $maxarrived,
+    ) = get_counts();
+    $dbh->commit();
+
+    my $used_pages = $page_count - $freelist_count;
+    my $logical_size = $page_count * $page_size;
+    my $used_size = $used_pages * $page_size;
+    my $freelist_size = $freelist_count * $page_size;
+    my $freelist_share
+      = $page_count > 0 ? 100 * $freelist_count / $page_count : 0;
+    my $real_percent = $total > 0 ? 100 * $real / $total : 0;
+    my $remembered_percent
+      = $total > 0 ? 100 * $remembered / $total : 0;
+    my @auto_vacuum_names = qw(none full incremental);
+    my $auto_vacuum_name
+      = defined($auto_vacuum_names[$auto_vacuum])
+      ? $auto_vacuum_names[$auto_vacuum]
+      : "unknown ($auto_vacuum)";
+    my $database_file_size = file_size($dbpath);
+    my $wal_file_size = file_size("$dbpath-wal");
+    my $shm_file_size = file_size("$dbpath-shm");
+    my $journal_file_size = file_size("$dbpath-journal");
+    my $total_file_size
+      = $database_file_size
+      + $wal_file_size
+      + $shm_file_size
+      + $journal_file_size;
+
+    $schema_version
+      = defined($schema_version) ? $schema_version : "unknown";
+    print "Database file: $dbpath\n";
+    print "SQLite version: $sqlite_version\n";
+    print "Schema version: $schema_version\n";
+    print "Journal mode: $journal_mode\n";
+    print "Auto-vacuum: $auto_vacuum_name\n";
+    print "Page size: $page_size bytes\n";
+    print "Page count: $page_count\n";
+    print "Non-freelist pages: $used_pages\n";
+    print "Freelist pages: $freelist_count\n";
+    printf "Freelist share: %.1f%%\n", $freelist_share;
+    print "Logical database size: $logical_size bytes\n";
+    print "Non-freelist page capacity: $used_size bytes\n";
+    print "Freelist size: $freelist_size bytes\n";
+    print "Database file size: $database_file_size bytes\n";
+    print "WAL file size: $wal_file_size bytes\n";
+    print "Shared-memory file size: $shm_file_size bytes\n";
+    print "Rollback journal file size: $journal_file_size bytes\n";
+    print "Total SQLite file size: $total_file_size bytes\n";
+    print "Total entries: $total\n";
+    printf "Real entries: %d (%.1f%%)\n", $real, $real_percent;
+    printf "Remembered entries: %d (%.1f%%)\n",
+      $remembered, $remembered_percent;
+    print "Real entries with explicit expiration: $explicit_expiration\n";
+    if (defined($minarrived) && defined($maxarrived)) {
+        printf "Arrived range: %s .. %s\n",
+          strftime('%Y-%m-%d %H:%M:%S', localtime($minarrived)),
+          strftime('%Y-%m-%d %H:%M:%S', localtime($maxarrived));
+    } else {
+        print "Arrived range: (empty database)\n";
+    }
+}
+
 # Audit the history database for problems and report them (-A option, default).
 sub audit_history {
     my $problems = 0;
@@ -183,15 +283,16 @@ sub audit_history {
         $problems++;
     }
 
-    # Entry counts.
-    my ($total, $real, $remembered) = get_counts();
+    # Entry counts and arrival range.
+    my (
+        $total,               $real,
+        $remembered,          $explicit_expiration_unused,
+        $minarrived,          $maxarrived,
+    ) = get_counts();
     print "Total entries: $total\n";
     print "Real entries (token not null): $real\n";
     print "Remembered entries (token null): $remembered\n";
 
-    # Arrived time range.
-    my ($minarrived, $maxarrived)
-      = $dbh->selectrow_array("select min(arrived), max(arrived) from hist;");
     if (defined($minarrived) and defined($maxarrived)) {
         printf "Arrived range: %s .. %s\n",
           strftime('%Y-%m-%d %H:%M:%S', localtime($minarrived)),

--- a/storage/ovsqlite/ovsqlite-util.in
+++ b/storage/ovsqlite/ovsqlite-util.in
@@ -30,7 +30,7 @@ eval {
 my $dbfile = "ovsqlite.db";
 
 my $usage = "Usage:
-  $0 [-AFghioO] [-a article] [-n newsgroup] [-p path]
+  $0 [-AFghioOs] [-a article] [-n newsgroup] [-p path]
 
 Options:
   -a article     Specify an article number or a range of article numbers on
@@ -51,7 +51,8 @@ Options:
   -O             Dump overview information for articles in the newsgroup
                  specified with -n, in the format used by overchan.
   -p path        Read $dbfile database file in path directory instead of
-                 default $INN::Config::pathoverview directory.
+                 default \$INN::Config::pathoverview directory.
+  -s             Print database storage and overview record statistics.
 ";
 
 sub HELP_MESSAGE {
@@ -63,7 +64,7 @@ my @unique_hash_keys_unused
   = qw(sqlite_allow_multiple_statements);    # perltidy -wuk
 
 my %opt;
-getopts("a:AFghioOn:p:", \%opt) || die $usage;
+getopts("a:AFghioOsn:p:", \%opt) || die $usage;
 
 HELP_MESSAGE() if defined($opt{'h'});
 
@@ -74,6 +75,7 @@ $modes++ if defined($opt{'g'});
 $modes++ if defined($opt{'i'});
 $modes++ if defined($opt{'o'});
 $modes++ if defined($opt{'O'});
+$modes++ if defined($opt{'s'});
 
 die "Can't use both -A and -F\n\n$usage"
   if defined($opt{'A'})
@@ -85,12 +87,21 @@ die "Only one action allowed at the same time\n\n$usage"
 die "A newsgroup must be specified with -n\n\n$usage"
   if (!defined($opt{'n'})
       && (defined($opt{'g'}) || defined($opt{'o'}) || defined($opt{'O'})));
+die "The -n option cannot be used with -s\n\n$usage"
+  if defined($opt{'n'}) and defined($opt{'s'});
+die "The -a option cannot be used with -s\n\n$usage"
+  if defined($opt{'a'}) and defined($opt{'s'});
 
 my ($low, $high, $compress, $basedict);
 my $sql_extraclause_artinfo = "";
 my $sql_extraclause_groupinfo = "";
-my $dbdir = $opt{'p'} || $INN::Config::pathoverview;
-my $datasource = "dbi:SQLite:dbname=$dbdir/$dbfile";
+my $dbdir;
+{
+    no warnings 'once';
+    $dbdir = $opt{'p'} || $INN::Config::pathoverview;
+}
+my $dbpath = "$dbdir/$dbfile";
+my $datasource = "dbi:SQLite:dbname=$dbpath";
 my $pausemsg = "ovsqlite-util fixes";    # Message when pausing INN.
                                          # Known line in innreport.
 my $ispaused = 0;
@@ -176,6 +187,8 @@ if (defined($opt{'A'}) or defined($opt{'F'})) {
     dump_artinfo_clients();
 } elsif (defined($opt{'O'})) {
     dump_artinfo_overchan();
+} elsif (defined($opt{'s'})) {
+    dump_statistics();
 }
 
 # Close the connection properly.
@@ -417,6 +430,111 @@ sub check_groupinfo_consistency {
 
     }
     pragma_foreign_keys(1);
+}
+
+# Return the size of a file, or 0 if the file does not exist.
+sub file_size {
+    my $path = shift;
+    my $size = -s $path;
+    return defined($size) ? $size : 0;
+}
+
+# Print database storage and overview record statistics (-s option).
+sub dump_statistics {
+    $dbh->do("savepoint ovsqlite_statistics;");
+    my ($sqlite_version)
+      = $dbh->selectrow_array("select sqlite_version();");
+    my ($schema_version)
+      = $dbh->selectrow_array(
+          "select value from misc where key = 'version';");
+    my ($journal_mode) = $dbh->selectrow_array("pragma journal_mode;");
+    my ($auto_vacuum) = $dbh->selectrow_array("pragma auto_vacuum;");
+    my ($page_size) = $dbh->selectrow_array("pragma page_size;");
+    my ($page_count) = $dbh->selectrow_array("pragma page_count;");
+    my ($freelist_count) = $dbh->selectrow_array("pragma freelist_count;");
+    my ($total_groups, $active_groups, $deleted_groups)
+      = $dbh->selectrow_array(
+        q{
+            select count(*),
+                   coalesce(sum(deleted = 0), 0),
+                   coalesce(sum(deleted > 0), 0)
+                from groupinfo;
+        },
+    );
+    my ($articles, $active_articles, $deleted_articles, $orphan_articles)
+      = $dbh->selectrow_array(
+        q{
+            with article_counts as
+                (select groupid, count(*) as articles
+                    from artinfo
+                    group by groupid)
+            select coalesce(sum(articles), 0),
+                   coalesce(sum(case when groupinfo.deleted = 0
+                                     then articles else 0 end), 0),
+                   coalesce(sum(case when groupinfo.deleted > 0
+                                     then articles else 0 end), 0),
+                   coalesce(sum(case when groupinfo.groupid is null
+                                     then articles else 0 end), 0)
+                from article_counts
+                    left join groupinfo using (groupid);
+        },
+    );
+    $dbh->do("release ovsqlite_statistics;");
+
+    my $used_pages = $page_count - $freelist_count;
+    my $logical_size = $page_count * $page_size;
+    my $used_size = $used_pages * $page_size;
+    my $freelist_size = $freelist_count * $page_size;
+    my $freelist_share
+      = $page_count > 0 ? 100 * $freelist_count / $page_count : 0;
+    my @auto_vacuum_names = qw(none full incremental);
+    my $auto_vacuum_name
+      = defined($auto_vacuum_names[$auto_vacuum])
+      ? $auto_vacuum_names[$auto_vacuum]
+      : "unknown ($auto_vacuum)";
+    my $compression = "unknown";
+    if (defined($compress)) {
+        $compression = $compress > 0 ? "enabled" : "disabled";
+    }
+    my $database_file_size = file_size($dbpath);
+    my $wal_file_size = file_size("$dbpath-wal");
+    my $shm_file_size = file_size("$dbpath-shm");
+    my $journal_file_size = file_size("$dbpath-journal");
+    my $total_file_size
+      = $database_file_size
+      + $wal_file_size
+      + $shm_file_size
+      + $journal_file_size;
+
+    $schema_version
+      = defined($schema_version) ? $schema_version : "unknown";
+
+    print "Database file: $dbpath\n";
+    print "SQLite version: $sqlite_version\n";
+    print "Schema version: $schema_version\n";
+    print "Journal mode: $journal_mode\n";
+    print "Auto-vacuum: $auto_vacuum_name\n";
+    print "Compression: $compression\n";
+    print "Page size: $page_size bytes\n";
+    print "Page count: $page_count\n";
+    print "Non-freelist pages: $used_pages\n";
+    print "Freelist pages: $freelist_count\n";
+    printf "Freelist share: %.1f%%\n", $freelist_share;
+    print "Logical database size: $logical_size bytes\n";
+    print "Non-freelist page capacity: $used_size bytes\n";
+    print "Freelist size: $freelist_size bytes\n";
+    print "Database file size: $database_file_size bytes\n";
+    print "WAL file size: $wal_file_size bytes\n";
+    print "Shared-memory file size: $shm_file_size bytes\n";
+    print "Rollback journal file size: $journal_file_size bytes\n";
+    print "Total SQLite file size: $total_file_size bytes\n";
+    print "Total groups: $total_groups\n";
+    print "Active groups: $active_groups\n";
+    print "Deleted groups: $deleted_groups\n";
+    print "Total articles: $articles\n";
+    print "Articles in active groups: $active_articles\n";
+    print "Articles in deleted groups: $deleted_articles\n";
+    print "Orphan articles: $orphan_articles\n";
 }
 
 # Dump overview information (-g option).

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -29,6 +29,7 @@ lib/headers
 lib/hex
 lib/hissqlite
 lib/hissqlite-convert
+lib/hissqlite-util
 lib/inet_aton
 lib/inet_ntoa
 lib/inet_ntop

--- a/tests/lib/hissqlite-util.t
+++ b/tests/lib/hissqlite-util.t
@@ -1,0 +1,143 @@
+#! /bin/sh
+#
+# Smoke test for hissqlite-util -s and -c against a minimal history database.
+#
+# Written by Kevin Bowling in 2026.
+
+count=1
+printcount() {
+    echo "$1 $count $2"
+    count=$(expr $count + 1)
+}
+
+# runtests preserves its caller's working directory.  Normalize to the test
+# build directory so this test works when runtests is called from either the
+# repository root or the tests directory.
+test_root=${C_TAP_BUILD:-}
+if [ -z "$test_root" ]; then
+    test_root=$(dirname "$0")
+    test_root=$(cd "$test_root/.." && pwd)
+fi
+if ! cd "$test_root"; then
+    echo "Bail out! cannot change to test directory $test_root"
+    exit 1
+fi
+
+util_source="../history/hissqlite/hissqlite-util.in"
+
+# Skip if SQLite support was not compiled in.
+if ! grep -q '^#define HAVE_SQLITE3' ../include/config.h 2>/dev/null; then
+    echo "1..0 # skip SQLite support not compiled"
+    exit 0
+fi
+
+# Run the source directly with -p so the test does not depend on an installed
+# INN::Config and innconfval.
+if [ ! -r "$util_source" ] \
+    || ! perl -MDBI -MDBD::SQLite -e 1 >/dev/null 2>&1; then
+    echo "1..0 # skip hissqlite-util dependencies unavailable"
+    exit 0
+fi
+
+echo 5
+
+tmpdir="$(pwd)/his-tmp-util"
+rm -rf "$tmpdir"
+mkdir -p "$tmpdir"
+
+# Create a minimal hissqlite schema with one real and one remembered entry.
+if ! perl -MDBI -MDBD::SQLite -e '
+use strict;
+use warnings;
+my $path = $ARGV[0];
+my $dbh = DBI->connect("dbi:SQLite:dbname=$path", "", "",
+    { RaiseError => 1, AutoCommit => 1 });
+$dbh->do(q{
+    create table hist (
+        hash blob not null primary key,
+        arrived integer not null,
+        posted integer,
+        expires integer,
+        token blob
+    ) without rowid
+});
+$dbh->do(q{
+    create index hist_remember on hist(posted, arrived)
+        where token is null
+});
+$dbh->do(q{
+    create table misc (
+        key text not null primary key,
+        value not null
+    ) without rowid
+});
+$dbh->do(
+    q{insert into misc(key, value) values(?, ?)},
+    undef, "version", 1
+);
+$dbh->do(q{
+    insert into hist(hash, arrived, posted, expires, token)
+        values(?, ?, ?, ?, ?)
+}, undef, pack("H*", "00112233445566778899aabbccddeeff"),
+    1600000000, 1600000000, 1600001000,
+    pack("H*", "0102030405060708090a0b0c0d0e0f10"));
+$dbh->do(q{
+    insert into hist(hash, arrived, posted, expires, token)
+        values(?, ?, ?, ?, ?)
+}, undef, pack("H*", "ffeeddccbbaa99887766554433221100"),
+    1600000001, 1600000001, 0, undef);
+$dbh->disconnect;
+' "$tmpdir/history.sqlite"; then
+    printcount "not ok" "# create test database"
+    printcount "not ok" "# statistics command"
+    printcount "not ok" "# schema version statistic"
+    printcount "not ok" "# entry counts"
+    printcount "not ok" "# count command"
+    rm -rf "$tmpdir"
+    exit 1
+fi
+printcount "ok" "# create test database"
+
+stats_output=$(perl "$util_source" -s -p "$tmpdir" 2>&1)
+stats_rc=$?
+count_output=$(perl "$util_source" -c -p "$tmpdir" 2>&1)
+count_rc=$?
+
+if [ $stats_rc -eq 0 ]; then
+    printcount "ok" "# statistics command"
+else
+    echo "# hissqlite-util -s failed (rc=$stats_rc):"
+    echo "$stats_output" | sed 's/^/# /'
+    printcount "not ok" "# statistics command"
+fi
+
+if echo "$stats_output" | grep -q '^Schema version: 1$'; then
+    printcount "ok" "# schema version statistic"
+else
+    printcount "not ok" "# schema version statistic"
+fi
+
+if echo "$stats_output" | grep -q '^Total entries: 2$' \
+    && echo "$stats_output" | grep -q '^Real entries: 1 (50.0%)$' \
+    && echo "$stats_output" | grep -q '^Remembered entries: 1 (50.0%)$' \
+    && echo "$stats_output" \
+        | grep -q '^Real entries with explicit expiration: 1$'; then
+    printcount "ok" "# entry counts"
+else
+    echo "# unexpected -s entry counts:"
+    echo "$stats_output" | sed 's/^/# /'
+    printcount "not ok" "# entry counts"
+fi
+
+if [ $count_rc -eq 0 ] \
+    && echo "$count_output" | grep -q '^total 2$' \
+    && echo "$count_output" | grep -q '^real 1$' \
+    && echo "$count_output" | grep -q '^remembered 1$'; then
+    printcount "ok" "# count command"
+else
+    echo "# hissqlite-util -c failed (rc=$count_rc):"
+    echo "$count_output" | sed 's/^/# /'
+    printcount "not ok" "# count command"
+fi
+
+rm -rf "$tmpdir"

--- a/tests/overview/ovsqlite-integ.t
+++ b/tests/overview/ovsqlite-integ.t
@@ -14,6 +14,19 @@ printcount() {
     count=$(expr $count + 1)
 }
 
+# runtests preserves its caller's working directory.  Normalize to the test
+# build directory so this test works when runtests is called from either the
+# repository root or the tests directory.
+test_root=${C_TAP_BUILD:-}
+if [ -z "$test_root" ]; then
+    test_root=$(dirname "$0")
+    test_root=$(cd "$test_root/.." && pwd)
+fi
+if ! cd "$test_root"; then
+    echo "Bail out! cannot change to test directory $test_root"
+    exit 1
+fi
+
 # Find the right directory.
 dirs='../data data tests/data'
 for dir in $dirs; do
@@ -30,6 +43,7 @@ fi
 server="../../storage/ovsqlite/ovsqlite-server"
 writer="overview/ovsqlite-write.t"
 reader="overview/ovsqlite-read.t"
+util_source="../storage/ovsqlite/ovsqlite-util.in"
 
 # When run from the tests directory, adjust paths.
 if [ ! -x "$server" ]; then
@@ -55,7 +69,7 @@ for prog in "$server" "$writer" "$reader"; do
     fi
 done
 
-echo 13
+echo 21
 
 # Set up temp directory with config files.  Use absolute paths because
 # the C test programs chdir to the test data directory before reading
@@ -151,7 +165,79 @@ else
     printcount "ok" "# server stopped (signal)"
 fi
 
-# Tests 6-10: run the reader (5 TAP tests from inside).
+# Tests 6-13: report database statistics with ovsqlite-util.
+# Run the source directly with -p so the test does not depend on an installed
+# INN::Config and innconfval.
+if [ ! -r "$util_source" ] \
+    || ! perl -MDBI -MDBD::SQLite -MCompress::Zlib -e 1 \
+        >/dev/null 2>&1; then
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+    printcount "ok" "# skip ovsqlite-util dependencies unavailable"
+else
+    stats_output=$(perl "$util_source" -s -p "$tmpdir" 2>&1)
+    stats_rc=$?
+    if [ $stats_rc -eq 0 ]; then
+        printcount "ok" "# statistics command"
+    else
+        echo "# ovsqlite-util -s failed (rc=$stats_rc):"
+        echo "$stats_output" | sed 's/^/# /'
+        printcount "not ok" "# statistics command"
+    fi
+    if echo "$stats_output" | grep -q '^Schema version: 1$'; then
+        printcount "ok" "# schema version statistic"
+    else
+        printcount "not ok" "# schema version statistic"
+    fi
+    if echo "$stats_output" | grep -q '^Journal mode: wal$'; then
+        printcount "ok" "# journal mode statistic"
+    else
+        printcount "not ok" "# journal mode statistic"
+    fi
+    if echo "$stats_output" | grep -q '^Compression: enabled$'; then
+        printcount "ok" "# compression statistic"
+    else
+        printcount "not ok" "# compression statistic"
+    fi
+    if echo "$stats_output" | grep -q '^Page count: [1-9][0-9]*$'; then
+        printcount "ok" "# page count statistic"
+    else
+        printcount "not ok" "# page count statistic"
+    fi
+    if echo "$stats_output" | grep -q '^Total groups: 11$' \
+        && echo "$stats_output" | grep -q '^Active groups: 11$' \
+        && echo "$stats_output" | grep -q '^Deleted groups: 0$'; then
+        printcount "ok" "# group count statistics"
+    else
+        echo "# unexpected -s group counts:"
+        echo "$stats_output" | sed 's/^/# /'
+        printcount "not ok" "# group count statistics"
+    fi
+    if echo "$stats_output" | grep -q '^Total articles: 99$' \
+        && echo "$stats_output" \
+            | grep -q '^Articles in active groups: 99$' \
+        && echo "$stats_output" \
+            | grep -q '^Articles in deleted groups: 0$' \
+        && echo "$stats_output" | grep -q '^Orphan articles: 0$'; then
+        printcount "ok" "# article count statistics"
+    else
+        echo "# unexpected -s article counts:"
+        echo "$stats_output" | sed 's/^/# /'
+        printcount "not ok" "# article count statistics"
+    fi
+    if echo "$stats_output" | grep -q '^WAL file size: [0-9][0-9]* bytes$'; then
+        printcount "ok" "# WAL file size statistic"
+    else
+        printcount "not ok" "# WAL file size statistic"
+    fi
+fi
+
+# Tests 14-18: run the reader (5 TAP tests from inside).
 reader_output=$($reader 2>&1)
 reader_rc=$?
 reader_count=$(echo "$reader_output" | grep -c "^ok ")
@@ -171,7 +257,7 @@ else
     printcount "not ok" "# reopen"
 fi
 
-# Tests 11-13: server restart resilience.
+# Tests 19-21: server restart resilience.
 # Simulate INN restart: start a new server against the existing WAL database,
 # shut it down, verify the reader can still read all data.  This is the
 # scenario where nnrpd outlives a server restart cycle.


### PR DESCRIPTION
Add some SQLite stats to the utils.  Because of direct readers we can't easily track total runtime info, so this is just the file level info.

Will help determine the value of VACUUM.