### PR TITLE
expireover: Size Bloom filter via history backend 

### DIFF
--- a/doc/pod/hissqlite.pod
+++ b/doc/pod/hissqlite.pod
@@ -5,8 +5,8 @@ hissqlite - SQLite-based history storage method for INN
 =head1 DESCRIPTION
 
 This method uses SQLite to store the history database, as an alternative to
-the default C<hisv6> method.  It requires version 3.8.2 or later of the
-SQLite library (3.20.0+ recommended).
+the default C<hisv6> method.  It requires version 3.24.0 or later of the
+SQLite library.
 
 SQLite source, documentation, etc. are available at
 L<https://www.sqlite.org/>.  One of the stated goals of the SQLite file

--- a/doc/pod/install.pod
+++ b/doc/pod/install.pod
@@ -188,7 +188,7 @@ versions you'll need:
     --with-python       Python 2.3.0 or higher, 2.5.0+ recommended
                         Python 3.3.0 or higher
     --with-sasl         Cyrus SASL 2.1.0 or higher
-    --with-sqlite3      SQLite 3.8.2 or higher, 3.20.0+ recommended
+    --with-sqlite3      SQLite 3.24.0 or higher
     --with-zlib         zlib 1.x or higher
 
 If any of these libraries (other than Perl or Python) are built shared and
@@ -477,14 +477,14 @@ explicitly passed to C<configure>.
 
 =item B<--with-sqlite3>=PATH
 
-Enables support for SQLite (3.8.2 or higher), which means that it
-will then be possible to use the ovsqlite overview method if you wish.
-Enabling this configure option doesn't mean you'll be required to use
-ovsqlite, but it does require that SQLite be installed on your system
-(including the header files, not just the runtime libraries).  If a
-path is given, it sets the installed directory of SQLite.  In case
-non-standard paths to the SQLite library are used, one or both of the
-options B<--with-sqlite3-include> and B<--with-sqlite3-lib> can be given
+Enables support for SQLite (3.24.0 or higher), which means that it
+will then be possible to use the ovsqlite overview method or the hissqlite
+history method if you wish.  Enabling this configure option doesn't mean
+you'll be required to use either method, but it does require that SQLite be
+installed on your system (including the header files, not just the runtime
+libraries).  If a path is given, it sets the installed directory of SQLite.
+In case non-standard paths to the SQLite library are used, one or both of
+the options B<--with-sqlite3-include> and B<--with-sqlite3-lib> can be given
 to C<configure> with a path.
 
 If the SQLite library is found at configure time, INN will be built

--- a/doc/pod/libinnhist.pod
+++ b/doc/pod/libinnhist.pod
@@ -30,7 +30,8 @@ libinnhist - Routines for managing INN history
         HISCTLS_NPAIRS,
         HISCTLS_IGNOREOLD,
         HISCTLS_STATINTERVAL,
-        HISCTLG_INPLACEEXPIRE
+        HISCTLG_INPLACEEXPIRE,
+        HISCTLG_ENTRYESTIMATE
     };
 
     struct history *HISopen(const char *path, const char *method,
@@ -327,6 +328,18 @@ so the caller must initialise it to false.  I<val> should be a pointer to a
 value of type B<bool> and will not be modified by the call.  expire(8) uses
 this to decide whether to open the history read/write (in place) or read-only
 (rebuild-and-swap, the hisv6 model).
+
+=item C<HISCTLG_ENTRYESTIMATE> (size_t *)
+
+Get a cheap, conservative overestimate of the number of entries in the
+history database, without scanning it, suitable for sizing data structures
+such as Bloom filters.  Each backend derives the estimate from its own
+on-disk layout: C<hisv6> divides the text file size by the minimum history
+line length, C<hissqlite> divides the allocated database pages by the
+minimum row footprint.  Returns false and leaves the value untouched if no
+estimate can be made; callers should fall back to their own default sizing.
+I<val> should be a pointer to a value of type B<size_t>.  expireover(8)
+uses this to size its Bloom filter before walking the history database.
 
 =back
 

--- a/doc/pod/news.pod
+++ b/doc/pod/news.pod
@@ -7,6 +7,11 @@ intervention may be needed:
 
 =item *
 
+The minimum supported SQLite version is now 3.24.0, released in June 2018.
+Older versions are no longer accepted at configure time.
+
+=item *
+
 SQLite's Write-Ahead Logging journal mode is now enabled by default.  This
 setting notably improves read performance when multiple B<nnrpd> processes
 access the overview database simultaneously.  However, it does not work on

--- a/doc/pod/ovsqlite.pod
+++ b/doc/pod/ovsqlite.pod
@@ -5,7 +5,7 @@ ovsqlite - SQLite-based overview storage method for INN
 =head1 DESCRIPTION
 
 This method uses SQLite to store overview data.  It requires version
-3.8.2 or later of the SQLite library (3.20.0+ recommended).
+3.24.0 or later of the SQLite library.
 
 SQLite source, documentation, etc. are available at
 L<https://www.sqlite.org/>.  Ones of the stated goals of the SQLite

--- a/expire/expireover.c
+++ b/expire/expireover.c
@@ -483,19 +483,14 @@ main(int argc, char *argv[])
        fall through to HISlookup for correctness (handles articles added after
        the walk). */
     if (innconf->expirebloomfp > 0 && !always_stat) {
-        struct stat st;
-        char *histpath;
         size_t estimated = 0;
-        /* Minimum history line: 34 (hash) + 1 (tab) + 1 (arrived)
-         * + 1 (newline).  Dividing file size by this gives a conservative
-         * overestimate of entries, which is what we want for Bloom sizing. */
-        const size_t min_history_line = 37;
 
-        histpath = concatpath(innconf->pathhistory, INN_PATH_HISTORY);
-        if (stat(histpath, &st) == 0)
-            estimated = st.st_size / min_history_line;
-        else
-            warn("can't stat %s, Bloom filter will be undersized", histpath);
+        /* Each history backend derives a conservative overestimate of its
+           entry count from its own on-disk layout (hisv6: text file size /
+           minimum line; hissqlite: allocated pages / minimum row). */
+        if (!HISctl(history, HISCTLG_ENTRYESTIMATE, &estimated))
+            warn("can't estimate history entries, Bloom filter will be"
+                 " undersized");
         bloom = bloom_create(estimated, innconf->expirebloomfp);
         if (!HISwalk(history, NULL, bloom, build_bloom_cb)) {
             warn("can't walk history for Bloom filter, using per-article"
@@ -504,7 +499,6 @@ main(int argc, char *argv[])
             bloom = NULL;
         }
         OVctl(OVTOKENCACHE, &bloom);
-        free(histpath);
     }
 
     /* Loop through each line of the input file and process each group,

--- a/history/hissqlite/hissqlite-convert.c
+++ b/history/hissqlite/hissqlite-convert.c
@@ -183,11 +183,11 @@ main(int argc, char *argv[])
     /* Plain INSERT (not OR IGNORE): a duplicate hash returns SQLITE_CONSTRAINT
        so convert_cb can count it instead of silently dropping the row. */
     checked(st.db,
-            sqlite3_prepare_v2(st.db,
+            sqlite3_prepare_v3(st.db,
                                "insert into hist"
                                "(hash, arrived, posted, expires, token)"
                                " values(?1, ?2, ?3, ?4, ?5)",
-                               -1, &st.insert, NULL),
+                               -1, SQLITE_PREPARE_PERSISTENT, &st.insert, NULL),
             "prepare insert");
 
     src = HISopen(srcpath, srcmethod, HIS_RDONLY);

--- a/history/hissqlite/hissqlite-private.h
+++ b/history/hissqlite/hissqlite-private.h
@@ -38,6 +38,15 @@
    long expire does not pin the WAL. */
 #define HISSQLITE_EXPIRE_BATCH    10000
 
+/* Smallest possible on-disk footprint of a hist row, for the
+   HISCTLG_ENTRYESTIMATE overestimate (allocated bytes / this >= row count).
+   The minimum row is a remembered entry (expires/token NULL): record header
+   (6) + hash (16) + arrived (4) + posted (4) payload, plus the payload-length
+   varint and 2-byte cell pointer, ~33 bytes; real article rows, page headers,
+   B-tree fill factor, and interior pages only push the true per-row cost
+   higher.  32 keeps the division a strict overestimate. */
+#define HISSQLITE_MIN_ROW_BYTES   32
+
 /* HIS_INCORE (a bulk rebuild, makehistory) commits writes in transactions of
    this many rows instead of one each; matches hissqlite-convert's
    COMMIT_EVERY.  See the batch_* helpers in hissqlite.c. */

--- a/history/hissqlite/hissqlite.c
+++ b/history/hissqlite/hissqlite.c
@@ -253,6 +253,42 @@ hissqlite_is_wal(struct hissqlite *h)
 }
 
 /*
+**  Estimate the entry count from allocated database bytes.  The prepared
+**  query reads all three table-valued PRAGMAs in one statement, so they share
+**  one WAL snapshot even while another connection is writing.
+*/
+static bool
+hissqlite_entryestimate(struct hissqlite *h, size_t *out)
+{
+    sqlite3_stmt *stmt;
+    sqlite3_int64 bytes;
+    uint64_t estimate;
+    bool ok;
+    static const char query[] =
+        "select (page_count - freelist_count) * page_size"
+        " from pragma_page_count(), pragma_freelist_count(),"
+        " pragma_page_size()";
+
+    if (h->db == NULL)
+        return false;
+    if (sqlite3_prepare_v2(h->db, query, -1, &stmt, NULL) != SQLITE_OK) {
+        hissqlite_seterror(h, "prepare entry estimate");
+        return false;
+    }
+    ok = sqlite3_step(stmt) == SQLITE_ROW;
+    bytes = ok ? sqlite3_column_int64(stmt, 0) : -1;
+    if (!ok)
+        hissqlite_seterror(h, "estimate entries");
+    sqlite3_finalize(stmt);
+    if (bytes < 0)
+        return false;
+
+    estimate = (uint64_t) bytes / HISSQLITE_MIN_ROW_BYTES;
+    *out = estimate > SIZE_MAX ? SIZE_MAX : (size_t) estimate;
+    return true;
+}
+
+/*
 **  Open (or create) the database named by h->path and prepare the statement
 **  sets, using h->flags.  Factored out of hissqlite_open so the deferred-path
 **  pattern -- HISopen(NULL, ...) followed by HISCTLS_PATH, as makehistory uses
@@ -860,6 +896,15 @@ hissqlite_ctl(void *history, int selector, void *val)
            way.  See hissqlite_expire(). */
         *(bool *) val = true;
         return true;
+    case HISCTLG_ENTRYESTIMATE:
+        /* (page_count - freelist_count) * page_size is the allocated data
+           size as seen by this connection's snapshot (WAL included), read
+           from the database header in O(1); dividing by the smallest
+           possible row footprint overestimates the row count.  An exact
+           count(*) has no thin index to use on this WITHOUT ROWID table, so
+           it would traverse the whole clustered B-tree -- the very scan
+           callers such as expireover are about to make via HISwalk. */
+        return hissqlite_entryestimate(h, val);
     case HISCTLS_PATH:
         /* Deferred-open path (makehistory): HISopen(NULL) left the database
            unopened; set the real path now and perform the open/create.  Refuse

--- a/history/hisv6/hisv6.c
+++ b/history/hisv6/hisv6.c
@@ -1442,6 +1442,25 @@ hisv6_ctl(void *history, int selector, void *val)
         }
         break;
 
+    case HISCTLG_ENTRYESTIMATE: {
+        /* Minimum history line: 34 (hash) + 1 (tab) + 1 (arrived)
+         * + 1 (newline).  Dividing the text file size by this gives a
+         * conservative overestimate of the entry count. */
+        const size_t min_history_line = 37;
+        struct stat st;
+
+        if (h->histpath == NULL || stat(h->histpath, &st) != 0)
+            r = false;
+        else {
+            uintmax_t estimate =
+                (uintmax_t) st.st_size / min_history_line;
+
+            *(size_t *) val =
+                estimate > SIZE_MAX ? SIZE_MAX : (size_t) estimate;
+        }
+        break;
+    }
+
     default:
         /* deliberately doesn't call hisv6_seterror as we don't want
          * to spam the error log if someone's passing in stuff which

--- a/include/inn/history.h
+++ b/include/inn/history.h
@@ -91,7 +91,16 @@ enum {
      * so the caller must initialise it to false.  expire(8) uses this to
      * decide whether to open the history read/write (in place) or read-only
      * (rebuild-and-swap, the hisv6 model). */
-    HISCTLG_INPLACEEXPIRE
+    HISCTLG_INPLACEEXPIRE,
+
+    /* (size_t) get a cheap, conservative overestimate of the number of
+     * entries in the history database, without scanning it, suitable for
+     * sizing data structures such as Bloom filters.  Each backend derives
+     * the estimate from its own on-disk layout.  Returns false (leaving the
+     * value untouched) if no estimate can be made; callers should fall back
+     * to their own default sizing.  expireover(8) uses this to size its
+     * Bloom filter before walking the history database. */
+    HISCTLG_ENTRYESTIMATE
 };
 
 struct history *HISopen(const char *, const char *, int);

--- a/include/inn/sqlite-helper.h
+++ b/include/inn/sqlite-helper.h
@@ -17,11 +17,6 @@
 #    include <sqlite3.h>
 #    include <stddef.h>
 
-/* SQLITE_PREPARE_PERSISTENT is defined in SQLite 3.20.0 and above. */
-#    ifndef SQLITE_PREPARE_PERSISTENT
-#        define SQLITE_PREPARE_PERSISTENT 0x00
-#    endif
-
 typedef struct sqlite_helper_t {
     size_t stmt_count;
     char const *text;

--- a/lib/sqlite-helper.c
+++ b/lib/sqlite-helper.c
@@ -11,23 +11,12 @@
 
 #ifdef HAVE_SQLITE3
 
-#    include <stdio.h>
 #    include <string.h>
-
-/* sqlite3_prepare_v3() is defined in SQLite 3.20.0 and above. */
-#    if SQLITE_VERSION_NUMBER >= 3020000
-#        define UNUSED_BEFORE_SQLITE_3_20
-#    else
-#        define UNUSED_BEFORE_SQLITE_3_20 UNUSED
-#        define sqlite3_prepare_v3(db, zSql, nByte, prepFlags, ppStmt, \
-                                   pzTail)                             \
-            sqlite3_prepare_v2(db, zSql, nByte, ppStmt, pzTail)
-#    endif
 
 int
 sqlite_helper_init(sqlite_helper_t const *helper, sqlite3_stmt **stmts,
                    sqlite3 *connection,
-                   unsigned int prepare_flags UNUSED_BEFORE_SQLITE_3_20,
+                   unsigned int prepare_flags,
                    char **errmsg)
 {
     int result;

--- a/m4/sqlite3.m4
+++ b/m4/sqlite3.m4
@@ -59,7 +59,7 @@ AC_DEFUN([_INN_LIB_SQLITE3_INTERNAL],
      AC_COMPUTE_INT([_INN_LIB_SQLITE3_VERSION], [SQLITE_VERSION_NUMBER],
         [#include <sqlite3.h>])
      AS_IF([test "x$_INN_LIB_SQLITE3_VERSION" != x],
-        [AS_IF([test "$_INN_LIB_SQLITE3_VERSION" -ge 3008002],
+        [AS_IF([test "$_INN_LIB_SQLITE3_VERSION" -ge 3024000],
             [inn_cv_have_sqlite3=yes],
             [inn_cv_have_sqlite3=no])],
         [inn_cv_have_sqlite3=no])

--- a/readme.pod
+++ b/readme.pod
@@ -150,15 +150,14 @@ or GnuPG, the latter being recommended.  See F<INSTALL> for more details.
 
 For the C<ovdb> overview storage method, you'll need S<Berkeley
 DB 4.4> or later (4.7 or later recommended).  For the C<ovsqlite>
-overview storage method, you'll need S<SQLite 3.8.2> or later (3.20.0
-or later recommended).  If you have zlib available, you can also compress
-overview before it's stored into C<ovdb> or C<ovsqlite>, and enable the
-COMPRESS capability, an NNTP extension.  For support for news reading
-over TLS, you'll need OpenSSL or LibreSSL.  To support SASL authentication
-to B<nnrpd> or to feed newsgroups to an IMAP server with SASL
-authentication, you'll need the Cyrus SASL libraries.  INN can also
-check passwords against a Kerberos KDC; for this, you will need Kerberos
-libraries.
+overview storage method, you'll need S<SQLite 3.24.0> or later.  If you
+have zlib available, you can also compress overview before it's stored
+into C<ovdb> or C<ovsqlite>, and enable the COMPRESS capability, an NNTP
+extension.  For support for news reading over TLS, you'll need OpenSSL or
+LibreSSL.  To support SASL authentication to B<nnrpd> or to feed newsgroups
+to an IMAP server with SASL authentication, you'll need the Cyrus SASL
+libraries.  INN can also check passwords against a Kerberos KDC; for this,
+you will need Kerberos libraries.
 
 =head1 Getting Started
 

--- a/support/getrra-c-util
+++ b/support/getrra-c-util
@@ -75,7 +75,7 @@ AC_DEFUN([_INN_LIB_SQLITE3_INTERNAL],\
      AC_COMPUTE_INT([_INN_LIB_SQLITE3_VERSION], [SQLITE_VERSION_NUMBER],\
         [#include <sqlite3.h>])\
      AS_IF([test "x$_INN_LIB_SQLITE3_VERSION" != x],\
-        [AS_IF([test "$_INN_LIB_SQLITE3_VERSION" -ge 3008002],\
+        [AS_IF([test "$_INN_LIB_SQLITE3_VERSION" -ge 3024000],\
             [inn_cv_have_sqlite3=yes],\
             [inn_cv_have_sqlite3=no])],\
         [inn_cv_have_sqlite3=no])\

--- a/tests/lib/hissqlite-t.c
+++ b/tests/lib/hissqlite-t.c
@@ -124,7 +124,7 @@ main(void)
     struct walkcount wc;
     bool has_token;
 
-    test_init(32);
+    test_init(34);
 
     strlcpy(tmpdir, "hissqlite-XXXXXX", sizeof(tmpdir));
     if (mkdtemp(tmpdir) == NULL)
@@ -480,6 +480,36 @@ main(void)
             HISclose(ar);
         if (aw != NULL)
             HISclose(aw);
+    }
+
+    /* HISCTLG_ENTRYESTIMATE: a cheap, conservative overestimate of the entry
+       count (expireover relies on it to size its Bloom filter).  The main
+       database peaked at N_TOKEN + N_REMEMBER rows and pages are never
+       returned to the filesystem, so the estimate must be at least that. */
+    {
+        struct history *eh;
+        size_t est = 0;
+
+        eh = HISopen(histpath, "hissqlite", HIS_RDONLY);
+        ok(33, eh != NULL && HISctl(eh, HISCTLG_ENTRYESTIMATE, &est)
+                   && est >= N_TOKEN + N_REMEMBER);
+        if (eh != NULL)
+            HISclose(eh);
+    }
+
+    /* hisv6 implements the estimate too (empty text file -> exactly 0,
+       distinguishable from left-untouched by pre-loading a sentinel). */
+    {
+        struct history *hv;
+        size_t est = (size_t) -1;
+        char hv6path[160];
+
+        snprintf(hv6path, sizeof(hv6path), "%s/hv6", tmpdir);
+        hv = HISopen(hv6path, "hisv6", HIS_RDWR);
+        ok(34, hv != NULL && HISctl(hv, HISCTLG_ENTRYESTIMATE, &est)
+                   && est == 0);
+        if (hv != NULL)
+            HISclose(hv);
     }
 
     {


### PR DESCRIPTION
Add a history method to get an entry estimate for sizing data structures.

For hissqlite this is tricky, a count() would be a full table scan.  So estimate it based on page use.

Bump the minimum SQLite version to 3.24.0 (needed by hissqlite for UPSERT, 3.20.0 needed for these pragma_ columns, remove compat code).