### PR TITLE
Fix non-security correctness and resource-lifetime defects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@
 /tests/lib/pwrite.t
 /tests/lib/qio.t
 /tests/lib/reallocarray.t
+/tests/lib/reservedfd.t
 /tests/lib/setenv.t
 /tests/lib/snprintf.t
 /tests/lib/strlcat.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -1014,6 +1014,7 @@ tests/lib/pread-t.c                   Tests for lib/pread.c
 tests/lib/pwrite-t.c                  Tests for lib/pwrite.c
 tests/lib/qio-t.c                     Tests for lib/qio.c
 tests/lib/reallocarray-t.c            Tests for lib/reallocarray.c
+tests/lib/reservedfd-t.c              Tests for reserved file descriptors
 tests/lib/setenv-t.c                  Tests for lib/setenv.c
 tests/lib/snprintf-t.c                Tests for lib/snprintf.c
 tests/lib/strlcat-t.c                 Tests for lib/strlcat.c

--- a/backends/innxbatch.c
+++ b/backends/innxbatch.c
@@ -490,14 +490,14 @@ main(int ac, char *av[])
 
         if (fstat(fd, &statbuf)) {
             syswarn("cannot stat %s, skipping", XBATCHname);
-            close(i);
+            close(fd);
             continue;
         }
 
         XBATCHsize = statbuf.st_size;
         if (XBATCHsize == 0) {
             warn("batch file %s is zero length, skipping", XBATCHname);
-            close(i);
+            close(fd);
             unlink(XBATCHname);
             continue;
         } else if (XBATCHsize > XBATCHbuffersize) {

--- a/backends/innxmit.c
+++ b/backends/innxmit.c
@@ -306,17 +306,26 @@ strel(int i)
 static bool
 REMwrite(char *p, int i, bool escdot)
 {
-    int size;
+    size_t capacity, needed, size;
 
-    /* Buffer too full? */
-    if (REMbuffend - REMbuffptr < i + 3) {
+    if (i < 0)
+        return false;
+
+    /* Space for the payload, optional dot-escape, and CRLF. */
+    needed = (size_t) i + 3;
+    if ((size_t) (REMbuffend - REMbuffptr) < needed) {
         if (!REMflush())
             return false;
-        if (REMbuffend - REMbuffer < i + 3) {
-            /* Line too long -- grow buffer. */
-            size = i * 2;
+        capacity = (size_t) (REMbuffend - REMbuffer);
+        if (capacity < needed) {
+            /* Line too long -- grow buffer without overflowing size_t. */
+            if (needed > SIZE_MAX / 2)
+                size = needed;
+            else
+                size = needed * 2;
             REMbuffer = xrealloc(REMbuffer, size);
-            REMbuffend = &REMbuffer[size];
+            REMbuffptr = REMbuffer;
+            REMbuffend = REMbuffer + size;
         }
     }
 

--- a/expire/expire.c
+++ b/expire/expire.c
@@ -780,6 +780,7 @@ main(int ac, char *av[])
             EXPusepost = true;
             break;
         case 'r':
+            free(EXPreason);
             EXPreason = xstrdup(optarg);
             break;
         case 's':
@@ -853,6 +854,7 @@ main(int ac, char *av[])
             EXPreason = xstrdup(buff);
         }
     } else {
+        free(EXPreason);
         EXPreason = NULL;
     }
 

--- a/frontends/encode.c
+++ b/frontends/encode.c
@@ -99,7 +99,7 @@ main(void)
 {
     char *p;
     int c;
-    char b3[3];
+    char b3[3] = {0, 0, 0};
 
     for (p = b3; (c = getchar()) != EOF;) {
         *p++ = (char) c;

--- a/innd/cc.c
+++ b/innd/cc.c
@@ -372,8 +372,8 @@ CCbegin(char *av[])
     /* Find the named site. */
     length = strlen(av[0]);
     for (strings = SITEreadfile(true), i = 0; (p = strings[i]) != NULL; i++)
-        if ((p[length] == NF_FIELD_SEP || p[length] == NF_SUBFIELD_SEP)
-            && strncasecmp(p, av[0], length) == 0) {
+        if (strncasecmp(p, av[0], length) == 0
+            && (p[length] == NF_FIELD_SEP || p[length] == NF_SUBFIELD_SEP)) {
             p = xstrdup(p);
             break;
         }
@@ -425,12 +425,15 @@ CCbegin(char *av[])
 static const char *
 CCdochange(NEWSGROUP *ngp, char *Rest)
 {
-    int length;
+    const char *end;
+    size_t length;
     char *p;
 
     if (ngp->Rest[0] == Rest[0]) {
         length = strlen(Rest);
-        if (ngp->Rest[length] == '\n' && strncmp(ngp->Rest, Rest, length) == 0)
+        end = strchr(ngp->Rest, '\n');
+        if (end != NULL && (size_t) (end - ngp->Rest) == length
+            && memcmp(ngp->Rest, Rest, length) == 0)
             return "0 Group status unchanged";
     }
     if (Mode != OMrunning)

--- a/innd/chan.c
+++ b/innd/chan.c
@@ -556,7 +556,7 @@ CHANname(CHANNEL *cp)
 CHANNEL *
 CHANfromdescriptor(int fd)
 {
-    if (fd < 0 || fd > channels.table_size)
+    if (fd < 0 || fd >= channels.table_size)
         return NULL;
     return &channels.table[fd];
 }

--- a/innd/innd.c
+++ b/innd/innd.c
@@ -476,8 +476,10 @@ main(int ac, char *av[])
             innconf->maxartsize = strtoul(optarg, NULL, 10);
             break;
         case 'm':
-            if (ModeReason)
+            if (ModeReason) {
                 free(ModeReason);
+                ModeReason = NULL;
+            }
             switch (*optarg) {
             default:
                 Usage();

--- a/innfeed/endpoint.c
+++ b/innfeed/endpoint.c
@@ -992,7 +992,7 @@ static IoStatus
 doExcept(EndPoint endp)
 {
     int optval;
-    socklen_t size;
+    socklen_t size = sizeof(optval);
     int fd = endPointFd(endp);
 
     if (getsockopt(fd, SOL_SOCKET, SO_ERROR, (char *) &optval, &size) != 0)

--- a/innfeed/imap_connection.c
+++ b/innfeed/imap_connection.c
@@ -1241,8 +1241,9 @@ AddControlMsg(connection_t *cxn, Article art, Buffer *bufs,
         /* huh?!? */
         d_printf(0, "%s:%u internal error in addControlMsg()\n",
                  hostPeerName(cxn->myHost), cxn->ident);
+        res = RET_FAIL;
     }
-    return RET_FAIL;
+    return res;
 }
 
 /*

--- a/innfeed/imap_connection.c
+++ b/innfeed/imap_connection.c
@@ -432,6 +432,7 @@ static void imap_Disconnect(connection_t *cxn);
 static void lmtp_DisconnectNoDelete(connection_t *cxn);
 static void imap_DisconnectNoDelete(connection_t *cxn);
 static conn_ret imap_listenintro(connection_t *cxn);
+static void CloseEndpoint(EndPoint *endpoint, int *sockfd);
 
 static void imap_writeTimeoutCbk(TimeoutId id, void *data);
 static void lmtp_writeTimeoutCbk(TimeoutId id, void *data);
@@ -1467,6 +1468,42 @@ SetSASLProperties(sasl_conn_t *conn, int sock, int minssf, int maxssf)
 /************************* Startup functions
  * **********************************/
 
+/*
+ * Close a protocol endpoint, or a socket that has not yet been transferred
+ * to an endpoint.
+ */
+static void
+CloseEndpoint(EndPoint *endpoint, int *sockfd)
+{
+    if (*endpoint != NULL) {
+        delEndPoint(*endpoint);
+        *endpoint = NULL;
+    } else if (*sockfd >= 0) {
+        close(*sockfd);
+    }
+    *sockfd = -1;
+}
+
+static void
+ClearLMTPCapabilities(connection_t *cxn)
+{
+    if (cxn->lmtp_capabilities == NULL)
+        return;
+    free(cxn->lmtp_capabilities->saslmechs);
+    free(cxn->lmtp_capabilities);
+    cxn->lmtp_capabilities = NULL;
+}
+
+static void
+ClearIMAPCapabilities(connection_t *cxn)
+{
+    if (cxn->imap_capabilities == NULL)
+        return;
+    free(cxn->imap_capabilities->saslmechs);
+    free(cxn->imap_capabilities);
+    cxn->imap_capabilities = NULL;
+}
+
 static conn_ret
 Initialize(connection_t *cxn, int respTimeout)
 {
@@ -1543,6 +1580,7 @@ init_net(char *serverFQDN, int port, int *sock)
     struct sockaddr_in addr;
     struct hostent *hp;
 
+    *sock = -1;
     if ((hp = gethostbyname(serverFQDN)) == NULL) {
         d_printf(0, "gethostbyname(): %s\n", strerror(errno));
         return RET_FAIL;
@@ -1560,6 +1598,8 @@ init_net(char *serverFQDN, int port, int *sock)
 
     if (connect((*sock), (struct sockaddr *) &addr, sizeof(addr)) < 0) {
         d_printf(0, "connect(): %s\n", strerror(errno));
+        close(*sock);
+        *sock = -1;
         return RET_FAIL;
     }
 
@@ -1582,6 +1622,9 @@ SetupLMTPConnection(connection_t *cxn, char *serverName, int port)
                  cxn->ident);
         return RET_FAIL;
     }
+
+    CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
+    ClearLMTPCapabilities(cxn);
 
 #ifdef HAVE_SASL
     /* Free the SASL connection if we already had one */
@@ -1617,16 +1660,11 @@ SetupLMTPConnection(connection_t *cxn, char *serverName, int port)
     cxn->lmtp_respBuffer = xmalloc(4096);
     cxn->lmtp_respBuffer[0] = '\0';
 
-    /* Free if we had an existing one */
-    if (cxn->lmtp_endpoint != NULL) {
-        delEndPoint(cxn->lmtp_endpoint);
-        cxn->lmtp_endpoint = NULL;
-    }
-
     cxn->lmtp_endpoint = newEndPoint(cxn->sockfd_lmtp);
     if (cxn->lmtp_endpoint == NULL) {
         d_printf(0, "%s:%u:LMTP failure creating endpoint\n",
                  hostPeerName(cxn->myHost), cxn->ident);
+        CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
         return RET_FAIL;
     }
 
@@ -1637,6 +1675,7 @@ SetupLMTPConnection(connection_t *cxn, char *serverName, int port)
     if (result != RET_OK) {
         d_printf(0, "%s:%u:LMTP error setting SASL properties\n",
                  hostPeerName(cxn->myHost), cxn->ident);
+        CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
         return RET_FAIL;
     }
 #endif /* HAVE_SASL */
@@ -1660,6 +1699,9 @@ SetupIMAPConnection(connection_t *cxn, char *serverName, int port)
                  cxn->ident);
         return RET_FAIL;
     }
+
+    CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
+    ClearIMAPCapabilities(cxn);
 
 #ifdef HAVE_SASL
     /* Free the SASL connection if we already had one */
@@ -1693,16 +1735,11 @@ SetupIMAPConnection(connection_t *cxn, char *serverName, int port)
     cxn->imap_respBuffer = xmalloc(4096);
     cxn->imap_respBuffer[0] = '\0';
 
-    /* Free if we had an existing one */
-    if (cxn->imap_endpoint != NULL) {
-        delEndPoint(cxn->imap_endpoint);
-        cxn->imap_endpoint = NULL;
-    }
-
     cxn->imap_endpoint = newEndPoint(cxn->imap_sockfd);
     if (cxn->imap_endpoint == NULL) {
         d_printf(0, "%s:%u:IMAP Failure creating imap endpoint\n",
                  hostPeerName(cxn->myHost), cxn->ident);
+        CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
         return RET_FAIL;
     }
 
@@ -1712,6 +1749,7 @@ SetupIMAPConnection(connection_t *cxn, char *serverName, int port)
     if (result != RET_OK) {
         d_printf(0, "%s:%u:IMAP Error setting sasl properties",
                  hostPeerName(cxn->myHost), cxn->ident);
+        CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
         return result;
     }
 #endif /* HAVE_SASL */
@@ -1806,6 +1844,8 @@ imap_Connect(connection_t *cxn)
 
     /* Listen to the intro and start the authenticating process */
     result = imap_listenintro(cxn);
+    if (result != RET_OK)
+        CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
 
     return result;
 }
@@ -1893,6 +1933,8 @@ imap_DisconnectNoDelete(connection_t *cxn)
     clearTimer(cxn->imap_readBlockedTimerId);
     clearTimer(cxn->imap_writeBlockedTimerId);
 
+    CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
+
     /* Give the active item and any queued items back to the host. */
     if (cxn->current_control != NULL)
         QueueForgetAbout(cxn, cxn->current_control, MSG_GIVE_BACK);
@@ -1902,7 +1944,8 @@ imap_DisconnectNoDelete(connection_t *cxn)
 
     cxn->imap_disconnects++;
 
-    cxn->imap_respBuffer[0] = '\0';
+    if (cxn->imap_respBuffer != NULL)
+        cxn->imap_respBuffer[0] = '\0';
 
     if (cxn->issue_quit == 0)
         prepareReopenCbk(cxn, 0);
@@ -1941,6 +1984,8 @@ lmtp_Connect(connection_t *cxn)
 
     /* Listen to the intro */
     result = lmtp_listenintro(cxn);
+    if (result != RET_OK)
+        CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
 
     return result;
 }
@@ -1953,6 +1998,8 @@ lmtp_DisconnectNoDelete(connection_t *cxn)
     cxn->lmtp_sleepTimerId = 0;
     clearTimer(cxn->lmtp_readBlockedTimerId);
     clearTimer(cxn->lmtp_writeBlockedTimerId);
+
+    CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
 
     /* Release locally-owned buffers before returning the active article. */
     if (cxn->current_bufs != NULL) {
@@ -1969,7 +2016,8 @@ lmtp_DisconnectNoDelete(connection_t *cxn)
 
     cxn->lmtp_disconnects++;
 
-    cxn->lmtp_respBuffer[0] = '\0';
+    if (cxn->lmtp_respBuffer != NULL)
+        cxn->lmtp_respBuffer[0] = '\0';
 
     if (cxn->issue_quit == 0)
         prepareReopenCbk(cxn, 1);
@@ -2147,14 +2195,7 @@ lmtp_getcapabilities(connection_t *cxn)
     conn_ret result;
     char *p;
 
-    if (cxn->lmtp_capabilities != NULL) {
-        if (cxn->lmtp_capabilities->saslmechs) {
-            free(cxn->lmtp_capabilities->saslmechs);
-        }
-        free(cxn->lmtp_capabilities);
-        cxn->lmtp_capabilities = NULL;
-    }
-
+    ClearLMTPCapabilities(cxn);
     cxn->lmtp_capabilities = xcalloc(1, sizeof(lmtp_capabilities_t));
     cxn->lmtp_capabilities->saslmechs = NULL;
 
@@ -3219,10 +3260,8 @@ reset:
             d_printf(1, "%s:%u:IMAP Read quit response\n",
                      hostPeerName(cxn->myHost), cxn->ident);
 
-            cxn->imap_state = IMAP_DISCONNECTED;
-
-            DeleteIfDisconnected(cxn);
-            break;
+            imap_Disconnect(cxn);
+            return;
 
         default:
             d_printf(0, "%s:%u:IMAP I don't understand state %u [%s]\n",
@@ -3675,10 +3714,8 @@ reset:
         d_printf(1, "%s:%u:LMTP read quit\n", hostPeerName(cxn->myHost),
                  cxn->ident);
 
-        cxn->lmtp_state = LMTP_DISCONNECTED;
-
-        DeleteIfDisconnected(cxn);
-        break;
+        lmtp_Disconnect(cxn);
+        return;
 
     default:
 
@@ -4241,10 +4278,16 @@ delConnection(Connection cxn)
 
     ASSERT(c != NULL);
 
-    if (cxn->lmtp_endpoint != NULL)
-        delEndPoint(cxn->lmtp_endpoint);
-    if (cxn->imap_endpoint != NULL)
-        delEndPoint(cxn->imap_endpoint);
+    CloseEndpoint(&cxn->lmtp_endpoint, &cxn->sockfd_lmtp);
+    CloseEndpoint(&cxn->imap_endpoint, &cxn->imap_sockfd);
+    ClearLMTPCapabilities(cxn);
+    ClearIMAPCapabilities(cxn);
+#ifdef HAVE_SASL
+    if (cxn->saslconn_lmtp != NULL)
+        sasl_dispose(&cxn->saslconn_lmtp);
+    if (cxn->imap_saslconn != NULL)
+        sasl_dispose(&cxn->imap_saslconn);
+#endif /* HAVE_SASL */
 
     delBuffer(cxn->imap_rBuffer);
     delBuffer(cxn->lmtp_rBuffer);
@@ -4323,6 +4366,8 @@ newConnection(Host host, unsigned int ident, const char *ipname,
 
     /* allocate connection structure */
     cxn = xcalloc(1, sizeof(connection_t));
+    cxn->sockfd_lmtp = -1;
+    cxn->imap_sockfd = -1;
 
     cxn->ident = ident;
     cxn->ServerName = xstrdup(ipname);

--- a/innfeed/imap_connection.c
+++ b/innfeed/imap_connection.c
@@ -293,7 +293,6 @@ typedef struct connection_s {
     lmtp_capabilities_t *lmtp_capabilities;
 
     int lmtp_disconnects;
-    char *lmtp_tofree_str;
 
     article_queue_t *current_article;
     Buffer *current_bufs;
@@ -341,7 +340,6 @@ typedef struct connection_s {
 
     imap_state_t imap_state;
     int imap_disconnects;
-    char *imap_tofree_str;
 
     char imap_currentTag[IMAP_TAGLENGTH + 1];
     int imap_tag_num;
@@ -655,6 +653,9 @@ PopFromQueue(Q_t *q, article_queue_t **item)
 static void
 ReQueue(connection_t *cxn, Q_t *q, article_queue_t *entry)
 {
+    if (entry == cxn->current_article)
+        cxn->current_article = NULL;
+
     /* look at the time it's been here */
     entry->nextsend =
         time(NULL) + (entry->trys * 30); /* xxx better formula? */
@@ -703,6 +704,9 @@ QueueForgetAbout(connection_t *cxn, article_queue_t *item,
                  enum failure_type failed)
 {
     Article art = NULL;
+
+    if (item == cxn->current_article)
+        cxn->current_article = NULL;
 
     switch (item->type) {
     case DELIVER:
@@ -935,7 +939,8 @@ WriteToWire(connection_t *cxn, EndpRWCB callback, EndPoint endp, Buffer *array)
     if (array == NULL)
         return RET_FAIL;
 
-    prepareWrite(endp, array, NULL, callback, cxn);
+    if (!prepareWrite(endp, array, NULL, callback, cxn))
+        return RET_FAIL;
 
     return RET_OK;
 }
@@ -953,10 +958,13 @@ WriteToWire_str(connection_t *cxn, EndpRWCB callback, EndPoint endp, char *str,
 
     buff = newBufferByCharP(str, slen + 1, slen);
     ASSERT(buff != NULL);
+    bufferSetDeletedCbk(buff, free, str);
 
     writeArr = makeBufferArray(buff, NULL);
 
     result = WriteToWire(cxn, callback, endp, writeArr);
+    if (result != RET_OK)
+        freeBufferArray(writeArr);
 
     return result;
 }
@@ -964,6 +972,8 @@ WriteToWire_str(connection_t *cxn, EndpRWCB callback, EndPoint endp, char *str,
 static conn_ret
 WriteToWire_imapstr(connection_t *cxn, char *str, int slen)
 {
+    conn_ret result;
+
     /* prepare the timeouts */
     clearTimer(cxn->imap_readBlockedTimerId);
 
@@ -973,13 +983,18 @@ WriteToWire_imapstr(connection_t *cxn, char *str, int slen)
     if (cxn->imap_writeTimeout > 0)
         cxn->imap_writeBlockedTimerId =
             prepareSleep(imap_writeTimeoutCbk, cxn->imap_writeTimeout, cxn);
-    cxn->imap_tofree_str = str;
-    return WriteToWire_str(cxn, imap_writeCB, cxn->imap_endpoint, str, slen);
+    result =
+        WriteToWire_str(cxn, imap_writeCB, cxn->imap_endpoint, str, slen);
+    if (result != RET_OK)
+        clearTimer(cxn->imap_writeBlockedTimerId);
+    return result;
 }
 
 static conn_ret
 WriteToWire_lmtpstr(connection_t *cxn, char *str, int slen)
 {
+    conn_ret result;
+
     /* prepare the timeouts */
     clearTimer(cxn->lmtp_readBlockedTimerId);
 
@@ -990,8 +1005,11 @@ WriteToWire_lmtpstr(connection_t *cxn, char *str, int slen)
         cxn->lmtp_writeBlockedTimerId =
             prepareSleep(lmtp_writeTimeoutCbk, cxn->lmtp_writeTimeout, cxn);
 
-    cxn->lmtp_tofree_str = str;
-    return WriteToWire_str(cxn, lmtp_writeCB, cxn->lmtp_endpoint, str, slen);
+    result =
+        WriteToWire_str(cxn, lmtp_writeCB, cxn->lmtp_endpoint, str, slen);
+    if (result != RET_OK)
+        clearTimer(cxn->lmtp_writeBlockedTimerId);
+    return result;
 }
 
 static conn_ret
@@ -1875,8 +1893,10 @@ imap_DisconnectNoDelete(connection_t *cxn)
     clearTimer(cxn->imap_readBlockedTimerId);
     clearTimer(cxn->imap_writeBlockedTimerId);
 
-    DeferAllArticles(
-        cxn, &(cxn->imap_controlMsg_q)); /* give any articles back to Host */
+    /* Give the active item and any queued items back to the host. */
+    if (cxn->current_control != NULL)
+        QueueForgetAbout(cxn, cxn->current_control, MSG_GIVE_BACK);
+    DeferAllArticles(cxn, &(cxn->imap_controlMsg_q));
 
     cxn->imap_state = IMAP_DISCONNECTED;
 
@@ -1934,7 +1954,15 @@ lmtp_DisconnectNoDelete(connection_t *cxn)
     clearTimer(cxn->lmtp_readBlockedTimerId);
     clearTimer(cxn->lmtp_writeBlockedTimerId);
 
-    /* give any articles back to Host */
+    /* Release locally-owned buffers before returning the active article. */
+    if (cxn->current_bufs != NULL) {
+        freeBufferArray(cxn->current_bufs);
+        cxn->current_bufs = NULL;
+    }
+    if (cxn->current_article != NULL)
+        QueueForgetAbout(cxn, cxn->current_article, MSG_GIVE_BACK);
+
+    /* Give any queued articles back to the host. */
     DeferAllArticles(cxn, &(cxn->lmtp_todeliver_q));
 
     cxn->lmtp_state = LMTP_DISCONNECTED;
@@ -2194,8 +2222,10 @@ lmtp_authenticate(connection_t *cxn)
 
         saslresult = sasl_encode64(out, outlen, inbase64, outlen * 2 + 8,
                                    (unsigned *) &inbase64len);
-        if (saslresult != SASL_OK)
+        if (saslresult != SASL_OK) {
+            free(inbase64);
             return RET_FAIL;
+        }
         p = concat("AUTH ", mechusing, " ", inbase64, "\r\n", (char *) 0);
         free(inbase64);
     }
@@ -2249,6 +2279,8 @@ lmtp_getauthline(char *str, char **line, int *linelen)
                                (unsigned *) linelen);
     if (saslresult != SASL_OK) {
         d_printf(0, "?:?:LMTP base64 decoding error\n");
+        free(*line);
+        *line = NULL;
         return STAT_NO;
     }
 
@@ -2257,18 +2289,21 @@ lmtp_getauthline(char *str, char **line, int *linelen)
 #endif /* HAVE_SASL */
 
 static void
-lmtp_writeCB(EndPoint e UNUSED, IoStatus i UNUSED, Buffer *b, void *d)
+lmtp_writeCB(EndPoint e, IoStatus i, Buffer *b, void *d)
 {
     connection_t *cxn = (connection_t *) d;
     Buffer *readBuffers;
 
     clearTimer(cxn->lmtp_writeBlockedTimerId);
 
-    /* Free the string that was written */
+    /* Free the buffers and their attached string. */
     freeBufferArray(b);
-    if (cxn->lmtp_tofree_str != NULL) {
-        free(cxn->lmtp_tofree_str);
-        cxn->lmtp_tofree_str = NULL;
+    if (i != IoDone) {
+        errno = endPointErrno(e);
+        syslog(LOG_ERR, "%s:%u LMTP write failed: %m",
+               hostPeerName(cxn->myHost), cxn->ident);
+        lmtp_Disconnect(cxn);
+        return;
     }
 
     /* set up to receive */
@@ -2334,18 +2369,21 @@ lmtp_writeCB(EndPoint e UNUSED, IoStatus i UNUSED, Buffer *b, void *d)
 
 
 static void
-imap_writeCB(EndPoint e UNUSED, IoStatus i UNUSED, Buffer *b, void *d)
+imap_writeCB(EndPoint e, IoStatus i, Buffer *b, void *d)
 {
     connection_t *cxn = (connection_t *) d;
     Buffer *readBuffers;
 
     clearTimer(cxn->imap_writeBlockedTimerId);
 
-    /* free the string we just wrote out */
+    /* Free the buffers and their attached string. */
     freeBufferArray(b);
-    if (cxn->imap_tofree_str != NULL) {
-        free(cxn->imap_tofree_str);
-        cxn->imap_tofree_str = NULL;
+    if (i != IoDone) {
+        errno = endPointErrno(e);
+        syslog(LOG_ERR, "%s:%u IMAP write failed: %m",
+               hostPeerName(cxn->myHost), cxn->ident);
+        imap_Disconnect(cxn);
+        return;
     }
 
     /* set up to receive */
@@ -2473,8 +2511,10 @@ imap_sendAuthStep(connection_t *cxn, char *str)
     saslresult = sasl_encode64(out, outlen, inbase64, outlen * 2 + 8,
                                (unsigned *) &inbase64len);
 
-    if (saslresult != SASL_OK)
+    if (saslresult != SASL_OK) {
+        free(inbase64);
         return RET_FAIL;
+    }
 
     /* Append endline. */
     strlcpy(inbase64 + inbase64len, "\r\n", outlen * 2 + 10 - inbase64len);
@@ -3439,6 +3479,7 @@ reset:
                          hostPeerName(cxn->myHost), cxn->ident,
                          sasl_errstring(saslresult, NULL, NULL));
 
+                free(inbase64);
                 lmtp_Disconnect(cxn);
                 return;
             }
@@ -3558,6 +3599,8 @@ reset:
                          hostPeerName(cxn->myHost), cxn->ident);
             }
 
+            freeBufferArray(cxn->current_bufs);
+            cxn->current_bufs = NULL;
             ReQueue(cxn, &(cxn->lmtp_todeliver_q), cxn->current_article);
 
             cxn->lmtp_state = LMTP_AUTHED_IDLE;
@@ -3569,6 +3612,8 @@ reset:
                 lmtp_Disconnect(cxn);
                 return;
             }
+            /* The endpoint owns the array once the write is registered. */
+            cxn->current_bufs = NULL;
 
             cxn->lmtp_state = LMTP_WRITING_CONTENTS;
         }
@@ -3879,19 +3924,23 @@ retry:
 
     switch (item->type) {
     case CREATE_FOLDER:
-        imap_CreateGroup(cxn, item->data.control->folder);
+        result = imap_CreateGroup(cxn, item->data.control->folder);
         break;
 
     case CANCEL_MSG:
-        imap_CancelMsg(cxn, item->data.control->folder);
+        result = imap_CancelMsg(cxn, item->data.control->folder);
         break;
 
     case DELETE_FOLDER:
-        imap_DeleteGroup(cxn, item->data.control->folder);
+        result = imap_DeleteGroup(cxn, item->data.control->folder);
         break;
     default:
+        result = RET_FAIL;
         break;
     }
+
+    if (result != RET_OK)
+        imap_Disconnect(cxn);
 
     return;
 }
@@ -3977,12 +4026,14 @@ retry:
     if (result == RET_OK) {
         result = AddControlMsg(cxn, item->data.article, bufs, control_header,
                                control_header_end, 1);
+        freeBufferArray(bufs);
         if (result != RET_OK) {
             d_printf(1, "%s:%u Error adding to [imap] control queue\n",
                      hostPeerName(cxn->myHost), cxn->ident);
             ReQueue(cxn, &(cxn->lmtp_todeliver_q), item);
             return;
         }
+        free(item);
 
         switch (cxn->imap_state) {
         case IMAP_IDLE_AUTHED:
@@ -4008,10 +4059,8 @@ retry:
         goto retry;
     }
 
-    if (cxn->current_bufs != NULL) {
-        /* freeBufferArray(cxn->current_bufs); */
-        cxn->current_bufs = NULL;
-    }
+    if (cxn->current_bufs != NULL)
+        freeBufferArray(cxn->current_bufs);
     cxn->current_bufs = bufs;
     cxn->current_article = item;
 
@@ -4030,6 +4079,8 @@ retry:
     if ((result != RET_OK) || (rcpt_list == NULL)) {
         d_printf(1, "%s:%u Didn't find Newsgroups header field\n",
                  hostPeerName(cxn->myHost), cxn->ident);
+        freeBufferArray(cxn->current_bufs);
+        cxn->current_bufs = NULL;
         QueueForgetAbout(cxn, cxn->current_article, MSG_FAIL_DELIVER);
         goto retry;
     }
@@ -4044,6 +4095,7 @@ retry:
     p = concat("RSET\r\n"
                "MAIL FROM:<",
                mailfrom_name, ">\r\n", rcpt_list, "DATA\r\n", (char *) 0);
+    free(rcpt_list);
 
     cxn->lmtp_state = LMTP_WRITING_UPTODATA;
     result = WriteToWire_lmtpstr(cxn, p, strlen(p));
@@ -4279,11 +4331,13 @@ newConnection(Host host, unsigned int ident, const char *ipname,
     /* setup mailfrom user */
     if (gethostname(hostname, MAXHOSTNAMELEN) != 0) {
         d_printf(0, "%s gethostname failed\n", ipname);
+        free(cxn->ServerName);
+        free(cxn);
         return NULL;
     }
 
-
-    mailfrom_name = concat("news@", hostname, (char *) 0);
+    if (mailfrom_name == NULL)
+        mailfrom_name = concat("news@", hostname, (char *) 0);
 
     cxn->next = gCxnList;
     gCxnList = cxn;

--- a/innfeed/imap_connection.c
+++ b/innfeed/imap_connection.c
@@ -426,10 +426,13 @@ static void QueueForgetAbout(connection_t *cxn, article_queue_t *item,
 
 static void delConnection(Connection cxn);
 static void DeleteIfDisconnected(Connection cxn);
+static void DisconnectBothAndDelete(Connection cxn, bool notify_dead);
 static void DeferAllArticles(connection_t *cxn, Q_t *q);
 
 static void lmtp_Disconnect(connection_t *cxn);
 static void imap_Disconnect(connection_t *cxn);
+static void lmtp_DisconnectNoDelete(connection_t *cxn);
+static void imap_DisconnectNoDelete(connection_t *cxn);
 static conn_ret imap_listenintro(connection_t *cxn);
 
 static void imap_writeTimeoutCbk(TimeoutId id, void *data);
@@ -1757,7 +1760,10 @@ lmtp_listenintro(connection_t *cxn)
 
     /* set up to receive */
     readBuffers = makeBufferArray(bufferTakeRef(cxn->lmtp_rBuffer), NULL);
-    prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn, 5);
+    if (!prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn, 5)) {
+        freeBufferArray(readBuffers);
+        return RET_FAIL;
+    }
 
     cxn->lmtp_state = LMTP_READING_INTRO;
 
@@ -1774,8 +1780,10 @@ imap_Connect(connection_t *cxn)
 
     ASSERT(cxn->imap_sleepTimerId == 0);
 
-    /* make the IMAP connection */ SetupIMAPConnection(cxn, cxn->ServerName,
-                                                       IMAP_PORT);
+    /* Make the IMAP connection. */
+    result = SetupIMAPConnection(cxn, cxn->ServerName, IMAP_PORT);
+    if (result != RET_OK)
+        return result;
 
     /* Listen to the intro and start the authenticating process */
     result = imap_listenintro(cxn);
@@ -1826,9 +1834,7 @@ imap_readTimeoutCbk(TimeoutId id, void *data)
     cxnLogStats(cxn, true);
 
     if (cxn->imap_state == IMAP_DISCONNECTED) {
-        imap_Disconnect(cxn);
-        lmtp_Disconnect(cxn);
-        delConnection(cxn);
+        DisconnectBothAndDelete(cxn, false);
     } else {
         imap_Disconnect(cxn);
     }
@@ -1861,7 +1867,7 @@ imap_reopenTimeoutCbk(TimeoutId id, void *data)
 }
 
 static void
-imap_Disconnect(connection_t *cxn)
+imap_DisconnectNoDelete(connection_t *cxn)
 {
     clearTimer(cxn->imap_sleepTimerId);
     cxn->imap_sleepTimerId = 0;
@@ -1880,6 +1886,12 @@ imap_Disconnect(connection_t *cxn)
     if (cxn->issue_quit == 0)
         prepareReopenCbk(cxn, 0);
 
+}
+
+static void
+imap_Disconnect(connection_t *cxn)
+{
+    imap_DisconnectNoDelete(cxn);
     DeleteIfDisconnected(cxn);
 }
 
@@ -1914,7 +1926,7 @@ lmtp_Connect(connection_t *cxn)
 
 
 static void
-lmtp_Disconnect(connection_t *cxn)
+lmtp_DisconnectNoDelete(connection_t *cxn)
 {
     clearTimer(cxn->lmtp_sleepTimerId);
     cxn->lmtp_sleepTimerId = 0;
@@ -1933,6 +1945,12 @@ lmtp_Disconnect(connection_t *cxn)
     if (cxn->issue_quit == 0)
         prepareReopenCbk(cxn, 1);
 
+}
+
+static void
+lmtp_Disconnect(connection_t *cxn)
+{
+    lmtp_DisconnectNoDelete(cxn);
     DeleteIfDisconnected(cxn);
 }
 
@@ -2029,9 +2047,7 @@ lmtp_readTimeoutCbk(TimeoutId id, void *data)
     cxnLogStats(cxn, true);
 
     if (cxn->lmtp_state == LMTP_DISCONNECTED) {
-        imap_Disconnect(cxn);
-        lmtp_Disconnect(cxn);
-        delConnection(cxn);
+        DisconnectBothAndDelete(cxn, false);
     } else {
         lmtp_Disconnect(cxn);
     }
@@ -2256,7 +2272,11 @@ lmtp_writeCB(EndPoint e UNUSED, IoStatus i UNUSED, Buffer *b, void *d)
 
     /* set up to receive */
     readBuffers = makeBufferArray(bufferTakeRef(cxn->lmtp_rBuffer), NULL);
-    prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn, 5);
+    if (!prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn, 5)) {
+        freeBufferArray(readBuffers);
+        lmtp_Disconnect(cxn);
+        return;
+    }
 
     /* set up the response timer. */
     clearTimer(cxn->lmtp_readBlockedTimerId);
@@ -2329,7 +2349,11 @@ imap_writeCB(EndPoint e UNUSED, IoStatus i UNUSED, Buffer *b, void *d)
 
     /* set up to receive */
     readBuffers = makeBufferArray(bufferTakeRef(cxn->imap_rBuffer), NULL);
-    prepareRead(cxn->imap_endpoint, readBuffers, imap_readCB, cxn, 5);
+    if (!prepareRead(cxn->imap_endpoint, readBuffers, imap_readCB, cxn, 5)) {
+        freeBufferArray(readBuffers);
+        imap_Disconnect(cxn);
+        return;
+    }
 
     /* set up the response timer. */
     clearTimer(cxn->imap_readBlockedTimerId);
@@ -2729,7 +2753,10 @@ imap_listenintro(connection_t *cxn)
 
     /* set up to receive */
     readBuffers = makeBufferArray(bufferTakeRef(cxn->imap_rBuffer), NULL);
-    prepareRead(cxn->imap_endpoint, readBuffers, imap_readCB, cxn, 5);
+    if (!prepareRead(cxn->imap_endpoint, readBuffers, imap_readCB, cxn, 5)) {
+        freeBufferArray(readBuffers);
+        return RET_FAIL;
+    }
 
     cxn->imap_state = IMAP_READING_INTRO;
 
@@ -2857,11 +2884,13 @@ reset:
         readBuffers = makeBufferArray(bufferTakeRef(cxn->imap_rBuffer), NULL);
 
         if (!prepareRead(e, readBuffers, imap_readCB, cxn, 1)) {
+            freeBufferArray(readBuffers);
             imap_Disconnect(cxn);
         }
         return;
 
     } else if (ret != RET_OK) {
+        imap_Disconnect(cxn);
         return;
     }
 
@@ -3253,7 +3282,11 @@ reset:
 
         /* set up to receive some more */
         readBuffers = makeBufferArray(bufferTakeRef(cxn->lmtp_rBuffer), NULL);
-        prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn, 5);
+        if (!prepareRead(cxn->lmtp_endpoint, readBuffers, lmtp_readCB, cxn,
+                         5)) {
+            freeBufferArray(readBuffers);
+            lmtp_Disconnect(cxn);
+        }
         return;
     }
 
@@ -4024,6 +4057,7 @@ retry:
     if (deliver_to_header) {
         char *to_list, *to_list_end;
         int i, len;
+        size_t to_list_len;
 
         result = FindHeader(cxn->current_bufs, "Followup-To", &to_list,
                             &to_list_end);
@@ -4045,8 +4079,10 @@ retry:
             cxn->current_bufs[i] = cxn->current_bufs[i - 1];
         }
 
+        to_list_len = strlen(to_list);
         cxn->current_bufs[0] =
-            newBufferByCharP(to_list, strlen(to_list + 1), strlen(to_list));
+            newBufferByCharP(to_list, to_list_len + 1, to_list_len);
+        bufferSetDeletedCbk(cxn->current_bufs[0], free, to_list);
     }
 
     hostArticleOffered(cxn->myHost, cxn);
@@ -4325,6 +4361,22 @@ DeleteIfDisconnected(Connection cxn)
     }
 }
 
+/*
+ * Disconnect both protocol endpoints before deleting the shared connection.
+ * issue_quit value 4 suppresses the normal delete-on-second-disconnect path,
+ * which would otherwise free cxn between these two calls.
+ */
+static void
+DisconnectBothAndDelete(Connection cxn, bool notify_dead)
+{
+    cxn->issue_quit = 4;
+    imap_DisconnectNoDelete(cxn);
+    lmtp_DisconnectNoDelete(cxn);
+    if (notify_dead)
+        hostCxnDead(cxn->myHost, cxn);
+    delConnection(cxn);
+}
+
 /* puts the connection into the wait state (i.e. waits for an article
    before initiating a connect). Can only be called right after
    newConnection returns, or while the Connection is in the (internal)
@@ -4335,6 +4387,7 @@ cxnWait(Connection cxn)
     cxn->issue_quit = 1;
 
     QuitIfIdle(cxn);
+    DeleteIfDisconnected(cxn);
 }
 
 /* The Connection will disconnect as if cxnDisconnect were called and then
@@ -4345,6 +4398,7 @@ cxnFlush(Connection cxn)
     cxn->issue_quit = 2;
 
     QuitIfIdle(cxn);
+    DeleteIfDisconnected(cxn);
 }
 
 
@@ -4375,6 +4429,7 @@ cxnTerminate(Connection cxn)
     DeferAllArticles(cxn, &(cxn->imap_controlMsg_q));
 
     QuitIfIdle(cxn);
+    DeleteIfDisconnected(cxn);
 }
 
 /* Blow away the connection gracelessly and immediately clean up */
@@ -4389,11 +4444,7 @@ cxnNuke(Connection cxn)
     DeferAllArticles(cxn, &(cxn->lmtp_todeliver_q));
     DeferAllArticles(cxn, &(cxn->imap_controlMsg_q));
 
-    imap_Disconnect(cxn);
-    lmtp_Disconnect(cxn);
-
-    hostCxnDead(cxn->myHost, cxn);
-    delConnection(cxn);
+    DisconnectBothAndDelete(cxn, true);
 }
 
 /*

--- a/lib/canlock.c
+++ b/lib/canlock.c
@@ -14,6 +14,31 @@
 #if defined(HAVE_CANLOCK)
 #    include <libcanlock-3/canlock.h>
 
+static bool
+alloc_canlock_buffer(char **canbuff, size_t *length)
+{
+    size_t count;
+
+    *canbuff = NULL;
+    if (secrets->canlockadmin->count
+        > SIZE_MAX - secrets->canlockuser->count)
+        return false;
+    count = secrets->canlockadmin->count + secrets->canlockuser->count;
+    if (count > (SIZE_MAX - 1) / 87)
+        return false;
+    *length = 87 * count + 1;
+    *canbuff = xmalloc(*length);
+    **canbuff = '\0';
+    return true;
+}
+
+static void
+free_canlock_buffer(char **canbuff)
+{
+    free(*canbuff);
+    *canbuff = NULL;
+}
+
 
 /*  Generate c-lock elements for the Cancel-Lock header field.
 **  This function expects a Message-ID, a username (possibly NULL) and the
@@ -42,12 +67,10 @@ gen_cancel_lock(const char *msgid, const char *username, char **canbuff)
     size_t i;
     size_t msgidlen;
     size_t canlockseclen;
-    size_t canbufflen =
-        (85 + 2) * (secrets->canlockadmin->count + secrets->canlockuser->count)
-        + 1; /* Computation explained above, with 2 extra bytes. */
+    size_t canbufflen;
 
-    *canbuff = xmalloc(canbufflen);
-    **canbuff = '\0';
+    if (!alloc_canlock_buffer(canbuff, &canbufflen))
+        return false;
 
     /* Grab the message-ID without leading and trailing spaces to obtain the
      * right data for the computation of c-lock elements. */
@@ -85,7 +108,7 @@ gen_cancel_lock(const char *msgid, const char *username, char **canbuff)
                     canlockseclen, (const unsigned char *) msgidstart,
                     msgidlen);
                 if (c_lock == NULL) {
-                    free(canbuff);
+                    free_canlock_buffer(canbuff);
                     return false;
                 }
 
@@ -101,7 +124,7 @@ gen_cancel_lock(const char *msgid, const char *username, char **canbuff)
                     canlockseclen, (const unsigned char *) msgidstart,
                     msgidlen);
                 if (c_lock == NULL) {
-                    free(canbuff);
+                    free_canlock_buffer(canbuff);
                     return false;
                 }
 
@@ -129,7 +152,7 @@ gen_cancel_lock(const char *msgid, const char *username, char **canbuff)
                                          (const unsigned char *) datalock,
                                          usernamelen + msgidlen);
                     if (c_lock == NULL) {
-                        free(canbuff);
+                        free_canlock_buffer(canbuff);
                         free(datalock);
                         return false;
                     }
@@ -147,7 +170,7 @@ gen_cancel_lock(const char *msgid, const char *username, char **canbuff)
                                          (const unsigned char *) datalock,
                                          usernamelen + msgidlen);
                     if (c_lock == NULL) {
-                        free(canbuff);
+                        free_canlock_buffer(canbuff);
                         free(datalock);
                         return false;
                     }
@@ -200,14 +223,12 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
     size_t i;
     size_t msgidlen;
     size_t canlockseclen;
-    size_t canbufflen =
-        (85 + 2) * (secrets->canlockadmin->count + secrets->canlockuser->count)
-        + 1; /* Computation explained above, with 2 extra bytes. */
+    size_t canbufflen;
     size_t usernamelen = 0;
     bool gencankey = false;
 
-    *canbuff = xmalloc(canbufflen);
-    **canbuff = '\0';
+    if (!alloc_canlock_buffer(canbuff, &canbufflen))
+        return false;
 
     /* Find the start of the Message-ID. */
     if (hdrcontrol != NULL) {
@@ -253,7 +274,7 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
                             canlockseclen, (const unsigned char *) datalock,
                             usernamelen + msgidlen);
                         if (c_key == NULL) {
-                            free(canbuff);
+                            free_canlock_buffer(canbuff);
                             free(datalock);
                             return false;
                         }
@@ -271,7 +292,7 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
                             canlockseclen, (const unsigned char *) datalock,
                             usernamelen + msgidlen);
                         if (c_key == NULL) {
-                            free(canbuff);
+                            free_canlock_buffer(canbuff);
                             free(datalock);
                             return false;
                         }
@@ -297,7 +318,7 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
                             canlockseclen, (const unsigned char *) msgidstart,
                             msgidlen);
                         if (c_key == NULL) {
-                            free(canbuff);
+                            free_canlock_buffer(canbuff);
                             return false;
                         }
 
@@ -314,7 +335,7 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
                             canlockseclen, (const unsigned char *) msgidstart,
                             msgidlen);
                         if (c_key == NULL) {
-                            free(canbuff);
+                            free_canlock_buffer(canbuff);
                             return false;
                         }
 
@@ -327,6 +348,8 @@ gen_cancel_key(const char *hdrcontrol, const char *hdrsupersedes,
         }
     }
 
+    if (!gencankey)
+        free_canlock_buffer(canbuff);
     return gencankey;
 }
 

--- a/lib/network-innbind.c
+++ b/lib/network-innbind.c
@@ -83,6 +83,7 @@ network_innbind(int fd, int family, const char *address, unsigned short port)
     char *path;
     char buff[128];
     int pipefds[2];
+    int original_fd = fd;
     pid_t child, result;
     int status;
 
@@ -100,6 +101,9 @@ network_innbind(int fd, int family, const char *address, unsigned short port)
     child = fork();
     if (child < 0) {
         syswarn("cannot fork innbind for %s, port %hu", address, port);
+        socket_close(pipefds[0]);
+        socket_close(pipefds[1]);
+        free(path);
         return INVALID_SOCKET;
     } else if (child == 0) {
         /* Restore signal disposition and mask */
@@ -109,6 +113,8 @@ network_innbind(int fd, int family, const char *address, unsigned short port)
         if (dup2(pipefds[1], 1) < 0)
             sysdie("cannot dup pipe to stdout");
         socket_close(pipefds[0]);
+        if (pipefds[1] != 1)
+            socket_close(pipefds[1]);
         if (execl(path, path, buff, (char *) 0) < 0)
             sysdie("cannot exec innbind for %s, port %hu", address, port);
     }
@@ -132,6 +138,7 @@ network_innbind(int fd, int family, const char *address, unsigned short port)
     } else if (strcmp(buff, "ok\n") != 0) {
         fd = INVALID_SOCKET;
     }
+    socket_close(pipefds[0]);
 
     /* Wait for the results of the child process. */
     do {
@@ -139,12 +146,16 @@ network_innbind(int fd, int family, const char *address, unsigned short port)
     } while (result == -1 && errno == EINTR);
     if (result != child) {
         syswarn("cannot wait for innbind for %s, port %hu", address, port);
+        if (fd != INVALID_SOCKET && fd != original_fd)
+            socket_close(fd);
         return INVALID_SOCKET;
     }
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
         return fd;
     else {
         warn("innbind failed for %s, port %hu", address, port);
+        if (fd != INVALID_SOCKET && fd != original_fd)
+            socket_close(fd);
         return INVALID_SOCKET;
     }
 }

--- a/lib/reservedfd.c
+++ b/lib/reservedfd.c
@@ -17,6 +17,7 @@
 
 #include "portable/system.h"
 
+#include <errno.h>
 #include <fcntl.h>
 
 #include "inn/libinn.h"
@@ -42,12 +43,13 @@ bool
 fdreserve(int fdnum)
 {
     static int allocated = 0;
-    int i, start = allocated;
+    int i;
 
     if (fdnum <= 0) {
         if (Reserved_fd != NULL) {
             for (i = 0; i < Maxfd; i++) {
-                fclose(Reserved_fd[i]);
+                if (Reserved_fd[i] != NULL)
+                    fclose(Reserved_fd[i]);
             }
             free(Reserved_fd);
             Reserved_fd = NULL;
@@ -59,25 +61,33 @@ fdreserve(int fdnum)
 
     /* Allocate Reserved_fd or extend it when needed. */
     if (Reserved_fd == NULL) {
-        Reserved_fd = xmalloc(fdnum * sizeof(FILE *));
+        Reserved_fd = xcalloc(fdnum, sizeof(FILE *));
         allocated = fdnum;
     } else {
         if (allocated < fdnum) {
-            Reserved_fd = xrealloc(Reserved_fd, fdnum * sizeof(FILE *));
+            Reserved_fd =
+                xreallocarray(Reserved_fd, fdnum, sizeof(FILE *));
+            memset(Reserved_fd + allocated, 0,
+                   (fdnum - allocated) * sizeof(FILE *));
             allocated = fdnum;
         } else if (Maxfd > fdnum) {
             for (i = fdnum; i < Maxfd; i++) {
-                fclose(Reserved_fd[i]);
+                if (Reserved_fd[i] != NULL)
+                    fclose(Reserved_fd[i]);
+                Reserved_fd[i] = NULL;
             }
         }
     }
 
-    for (i = start; i < fdnum; i++) {
+    for (i = 0; i < fdnum; i++) {
+        if (Reserved_fd[i] != NULL)
+            continue;
         if (((Reserved_fd[i] = fopen("/dev/null", "r")) == NULL)) {
             /* In case a file descriptor cannot be reserved,
              * close all of them. */
-            for (--i; i >= 0; i--)
-                fclose(Reserved_fd[i]);
+            for (i = 0; i < fdnum; i++)
+                if (Reserved_fd[i] != NULL)
+                    fclose(Reserved_fd[i]);
             free(Reserved_fd);
             Reserved_fd = NULL;
             allocated = 0;
@@ -108,11 +118,17 @@ Fopen(const char *name, const char *mode, int fdindex)
     if (name == NULL || *name == '\0')
         return NULL;
 
-    if (fdindex < 0 || fdindex > Maxfd || Reserved_fd[fdindex] == NULL)
+    if (fdindex < 0 || fdindex >= Maxfd || Reserved_fd[fdindex] == NULL)
         return fopen(name, mode);
 
     if ((nfp = freopen(name, mode, Reserved_fd[fdindex])) == NULL) {
-        Reserved_fd[fdindex] = freopen("/dev/null", "r", Reserved_fd[fdindex]);
+        int oerrno = errno;
+
+        /* A failed freopen closes the original stream, so it cannot be
+         * passed to freopen again.  Replenish the reserved slot with a new
+         * stream instead. */
+        Reserved_fd[fdindex] = fopen("/dev/null", "r");
+        errno = oerrno;
         return NULL;
     }
 
@@ -129,6 +145,7 @@ int
 Fclose(FILE *fp)
 {
     int i;
+    FILE *nfp;
 
     if (fp == NULL)
         return 0;
@@ -141,6 +158,16 @@ Fclose(FILE *fp)
     if (i >= Maxfd)
         return fclose(fp);
 
-    Reserved_fd[i] = freopen("/dev/null", "r", Reserved_fd[i]);
+    nfp = freopen("/dev/null", "r", Reserved_fd[i]);
+    if (nfp == NULL) {
+        int oerrno = errno;
+
+        /* A failed freopen closes the original stream, so replenish the
+         * reserved slot with a new stream. */
+        Reserved_fd[i] = fopen("/dev/null", "r");
+        errno = oerrno;
+        return EOF;
+    }
+    Reserved_fd[i] = nfp;
     return 0;
 }

--- a/nnrpd/auth-ext.c
+++ b/nnrpd/auth-ext.c
@@ -41,34 +41,37 @@ static struct process *
 start_process(struct client *client, const char *command, const char *dir)
 {
     struct process *process;
-    int rd[2], wr[2], er[2];
+    int rd[2] = {-1, -1};
+    int wr[2] = {-1, -1};
+    int er[2] = {-1, -1};
     pid_t pid;
-    char *path;
+    const char *path;
+    char *allocated_path = NULL;
     struct vector *args;
 
     /* Parse the command and find the path to the binary. */
     args = vector_split_space(command, NULL);
+    if (args->count == 0) {
+        warn("%s auth: empty external command", client->host);
+        vector_free(args);
+        return NULL;
+    }
     path = args->strings[0];
     if (path[0] != '/') {
-        path = concatpath(dir, path);
+        allocated_path = concatpath(dir, path);
+        path = allocated_path;
     }
 
     /* Set up the pipes and run the program. */
     if (pipe(rd) < 0 || pipe(wr) < 0 || pipe(er) < 0) {
         syswarn("%s auth: cannot create pipe", client->host);
-        return NULL;
+        goto fail;
     }
     pid = fork();
     switch (pid) {
     case -1:
-        close(rd[0]);
-        close(rd[1]);
-        close(wr[0]);
-        close(wr[1]);
-        close(er[0]);
-        close(er[1]);
         syswarn("%s auth: cannot fork", client->host);
-        return NULL;
+        goto fail;
     case 0:
         if (dup2(wr[0], 0) < 0 || dup2(rd[1], 1) < 0 || dup2(er[1], 2) < 0) {
             syswarn("%s auth: cannot set up file descriptors", client->host);
@@ -95,7 +98,26 @@ start_process(struct client *client, const char *command, const char *dir)
     process->read_fd = rd[0];
     process->write_fd = wr[1];
     process->error_fd = er[0];
+    free(allocated_path);
+    vector_free(args);
     return process;
+
+fail:
+    if (rd[0] >= 0)
+        close(rd[0]);
+    if (rd[1] >= 0)
+        close(rd[1]);
+    if (wr[0] >= 0)
+        close(wr[0]);
+    if (wr[1] >= 0)
+        close(wr[1]);
+    if (er[0] >= 0)
+        close(er[0]);
+    if (er[1] >= 0)
+        close(er[1]);
+    free(allocated_path);
+    vector_free(args);
+    return NULL;
 }
 
 

--- a/nnrpd/commands.c
+++ b/nnrpd/commands.c
@@ -97,6 +97,7 @@ PERMgeneric(char *av[], char *accesslist, size_t size)
     size_t j;
     int i, pan[2], status;
     pid_t pid;
+    ssize_t count;
     struct stat stb;
 
     av += 2;
@@ -159,6 +160,8 @@ PERMgeneric(char *av[], char *accesslist, size_t size)
         if (i == (long) innconf->maxforks) {
             Reply("%d Can't fork %s\r\n", NNTP_FAIL_ACTION, strerror(errno));
             syslog(L_FATAL, "can't fork %s %m", av[0]);
+            close(pan[PIPE_READ]);
+            close(pan[PIPE_WRITE]);
             return -1;
         }
         syslog(L_NOTICE, "can't fork %s -- waiting", av[0]);
@@ -194,12 +197,14 @@ PERMgeneric(char *av[], char *accesslist, size_t size)
     }
 
     close(pan[PIPE_WRITE]);
-    if (read(pan[PIPE_READ], path, sizeof(path)) < 0) {
+    count = read(pan[PIPE_READ], path, sizeof(path));
+    close(pan[PIPE_READ]);
+    waitpid(pid, &status, 0);
+    if (count < 0) {
         syslog(L_FATAL, "can't read %s %m", path);
         return 0;
     }
 
-    waitpid(pid, &status, 0);
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
         return 0;
 

--- a/nnrpd/perm.c
+++ b/nnrpd/perm.c
@@ -1703,6 +1703,10 @@ PERMgetpermissions(void)
     char *user[2];
     static ACCESSGROUP *noaccessconf;
 
+    free(VirtualPath);
+    VirtualPath = NULL;
+    VirtualPathlen = 0;
+
     if (ConfigBit == NULL) {
         if (PERMMAX % 8 == 0)
             ConfigBitsize = PERMMAX / 8;
@@ -1869,8 +1873,6 @@ PERMgetpermissions(void)
                       NNTP_FAIL_TERMINATING);
                 ExitWithStats(1, true);
             }
-            if (VirtualPath)
-                free(VirtualPath);
             if (strcasecmp(innconf->pathhost, PERMaccessconf->pathhost) == 0) {
                 /* Use domain, if pathhost in access realm matches one in
                  * inn.conf to differentiate virtual host. */
@@ -1892,8 +1894,7 @@ PERMgetpermissions(void)
                     concat(PERMaccessconf->pathhost, "!", (char *) 0);
             }
             VirtualPathlen = strlen(VirtualPath);
-        } else
-            VirtualPathlen = 0;
+        }
     } else {
         if (!noaccessconf)
             noaccessconf = xmalloc(sizeof(ACCESSGROUP));

--- a/nnrpd/perm.c
+++ b/nnrpd/perm.c
@@ -469,6 +469,8 @@ copy_accessgroup(ACCESSGROUP *orig)
         ret->backoff_db = xstrdup(orig->backoff_db);
     if (orig->newsmaster)
         ret->newsmaster = xstrdup(orig->newsmaster);
+    if (orig->addcanlockuser)
+        ret->addcanlockuser = xstrdup(orig->addcanlockuser);
     return (ret);
 }
 
@@ -607,6 +609,8 @@ free_accessgroup(ACCESSGROUP *del)
         free(del->backoff_db);
     if (del->newsmaster)
         free(del->newsmaster);
+    if (del->addcanlockuser)
+        free(del->addcanlockuser);
     free(del);
 }
 

--- a/storage/ovdb/ovdb.c
+++ b/storage/ovdb/ovdb.c
@@ -401,6 +401,7 @@ client_disconnect(void)
     if (clientfd != -1) {
         rs.what = CMD_QUIT;
         csend(&rs, sizeof(rs));
+        close(clientfd);
     }
     clientfd = -1;
 }

--- a/support/mkmanifest
+++ b/support/mkmanifest
@@ -328,6 +328,7 @@ tests/lib/pread.t
 tests/lib/pwrite.t
 tests/lib/qio.t
 tests/lib/reallocarray.t
+tests/lib/reservedfd.t
 tests/lib/setenv.t
 tests/lib/snprintf.t
 tests/lib/strlcat.t

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,7 @@ TESTS	= authprogs/ident.t expire/tombstone.t expire/tombstone-hisexpire.t \
 	lib/messageid.t lib/messages.t lib/mkstemp.t \
 	lib/network/addr-ipv4.t lib/network/addr-ipv6.t \
 	lib/network/client.t lib/network/server.t \
-	lib/pread.t lib/pwrite.t lib/qio.t lib/reallocarray.t \
+	lib/pread.t lib/pwrite.t lib/qio.t lib/reallocarray.t lib/reservedfd.t \
 	lib/setenv.t lib/snprintf.t lib/strlcat.t \
 	lib/strlcpy.t lib/tst.t lib/uwildmat.t lib/vector.t lib/wire.t \
 	lib/xwrite.t nnrpd/auth-ext.t overview/api.t overview/buffindexed.t \
@@ -273,6 +273,9 @@ lib/reallocarray.o: ../lib/reallocarray.c
 
 lib/reallocarray.t: lib/reallocarray.o lib/reallocarray-t.o tap/basic.o $(LIBINN)
 	$(LINK) lib/reallocarray.o lib/reallocarray-t.o tap/basic.o $(LIBINN)
+
+lib/reservedfd.t: lib/reservedfd-t.o tap/basic.o $(LIBINN)
+	$(LINK) lib/reservedfd-t.o tap/basic.o $(LIBINN) $(LIBS)
 
 lib/setenv.o: ../lib/setenv.c
 	$(CC) $(CFLAGS) -DTESTING -c -o $@ ../lib/setenv.c

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -47,6 +47,7 @@ lib/pread
 lib/pwrite
 lib/qio
 lib/reallocarray
+lib/reservedfd
 lib/setenv
 lib/snprintf
 lib/strlcat

--- a/tests/lib/reservedfd-t.c
+++ b/tests/lib/reservedfd-t.c
@@ -1,0 +1,38 @@
+/* Test suite for reserved stdio file descriptors. */
+
+#include "portable/system.h"
+
+#include "inn/libinn.h"
+#include "tap/basic.h"
+
+int
+main(void)
+{
+    FILE *file;
+
+    test_init(11);
+
+    ok(1, fdreserve(4));
+    ok(2, fdreserve(2));
+    ok(3, fdreserve(4));
+
+    file = Fopen("/dev/null", "r", 3);
+    ok(4, file != NULL);
+    ok_int(5, 0, Fclose(file));
+
+    /* The upper bound is exclusive and must fall back to ordinary fopen. */
+    file = Fopen("/dev/null", "r", 4);
+    ok(6, file != NULL);
+    ok_int(7, 0, Fclose(file));
+
+    /* A failed freopen closes its stream; the reserved slot must be rebuilt
+       with fopen before it can be reused. */
+    file = Fopen("/this/path/does/not/exist", "r", 0);
+    ok(8, file == NULL);
+    file = Fopen("/dev/null", "r", 0);
+    ok(9, file != NULL);
+    ok_int(10, 0, Fclose(file));
+
+    ok(11, fdreserve(0));
+    return 0;
+}

--- a/tests/nnrpd/auth-ext-t.c
+++ b/tests/nnrpd/auth-ext-t.c
@@ -112,8 +112,9 @@ int
 main(void)
 {
     struct client *client;
+    char *result;
 
-    plan(12 * 6);
+    plan(12 * 6 + 2);
 
     client = client_new();
 
@@ -136,5 +137,15 @@ main(void)
     test_external(client, "partial-error", NULL,
                   "example.com auth: program error: This is an error\n");
 
+    errors_capture();
+    result = auth_external(client, "", ".", NULL, NULL);
+    errors_uncapture();
+    is_string(NULL, result, "empty external command returns no user");
+    is_string("example.com auth: empty external command\n", errors,
+              "empty external command is reported");
+    free(errors);
+    errors = NULL;
+
+    free(client);
     return 0;
 }


### PR DESCRIPTION
## Summary

This PR collects 20 ordinary correctness and resource-lifetime fixes for the
2.8 development branch. The commits remain separate so maintainers can review
and selectively backport them.

The series addresses stale pointers after buffer growth, descriptor and heap
ownership, trusted-input bounds checks, authentication-helper cleanup, and
IMAP/LMTP connection lifecycle problems. It contains no security-advisory
patches.

## 2.7 backport recommendations

These recommendations use a conservative stable-branch policy. “Yes” means the
change is appropriate for 2.7, although conflicts may require a manual
backport. Feature-specific commits should be taken when that feature is built
or supported.

| Commit | Backport to 2.7? | Reason |
|--------|------------------|--------|
| `9e0cdf653` | Yes | Prevents innxmit from retaining stale write pointers after buffer growth. |
| `d6f825af3` | Yes | Small fix preventing stale `ModeReason` ownership and shutdown cleanup failures. |
| `225566cd4` | Yes | Repairs reserved-descriptor shrink/regrow behavior and error handling. |
| `02394e1ef` | Yes | Makes partial legacy encoding deterministic instead of consuming uninitialized padding. |
| `2e7396b44` | Yes | Fixes IMAP/LMTP connection and synthesized-header ownership; take with the other IMAP/LMTP commits below. |
| `955b2f811` | Yes | Prevents innxbatch from leaking its batch descriptor or closing an unrelated descriptor. |
| `6ac6ecec8` | Yes | Prevents stale virtual-path state after permissions are recalculated. |
| `c425317c8` | No | Command-line reason-string cleanup in a short-lived expire process; low stable-branch value. |
| `8b831868b` | Yes | Prevents inherited canlock configuration from sharing storage that may later be freed. |
| `0a39ea91c` | Yes | Rejects a one-past channel descriptor before returning an invalid channel pointer. |
| `529e3e821` | Yes | Prevents short local configuration records from causing out-of-bounds reads. |
| `9efd6238f` | Yes | Prevents descriptor leakage across repeated generic-authenticator requests. |
| `ee7612be4` | Yes | Fixes use of an uninitialized `socklen_t` in innfeed socket-error handling. |
| `04e6d9673` | Yes | Corrects canlock error-path ownership and checks aggregate allocation size. |
| `d66897954` | No | Closes one cached OVDB socket during process shutdown; negligible operational benefit. |
| `fabbade11` | Yes | Balances innbind helper descriptors and received-socket ownership on failure paths. |
| `be8fcd866` | Yes | Prevents per-request leaks and partial-pipe leaks when external authentication is enabled. |
| `2c3ea2651` | Yes | Restores successful IMAP control-message queuing; take with the other IMAP/LMTP commits. |
| `c20ff3df5` | Yes | Preserves dequeued IMAP/LMTP work across disconnects; take as part of the IMAP/LMTP set. |
| `248d1a58c` | Yes | Closes IMAP/LMTP sockets and endpoints on all connection and shutdown paths. |

The four IMAP/LMTP commits should be backported together and in their current
order:

1. `2e7396b44`
2. `2c3ea2651`
3. `c20ff3df5`
4. `248d1a58c`

