### PR TITLE
Harden parsers and storage backends against malformed local data

### DIFF
--- a/backends/actsync.c
+++ b/backends/actsync.c
@@ -1307,10 +1307,9 @@ get_ignore(char *filename, int *len)
         }
 
         /* remove any trailing spaces and tabs */
-        for (p = &line[strlen(line) - 1];
-             p >= line && (*p == ' ' || *p == '\t'); --p) {
-            *p = '\0';
-        }
+        p = line + strlen(line);
+        while (p > line && (p[-1] == ' ' || p[-1] == '\t'))
+            *--p = '\0';
 
         /* ignore line if the remainder of the line is empty */
         if (line[0] == '\0') {

--- a/backends/archive.c
+++ b/backends/archive.c
@@ -285,6 +285,10 @@ process_article(ARTHANDLE *art, const char *token, struct config *config)
         return;
     }
     end = wire_endheader(start, art->data + art->len - 1);
+    if (end == NULL) {
+        warn("unterminated Xref header field in %s", token);
+        return;
+    }
     xref = xstrndup(start, end - start);
     for (p = xref; *p != '\0'; p++)
         if (*p == '\r' || *p == '\n')
@@ -293,6 +297,7 @@ process_article(ARTHANDLE *art, const char *token, struct config *config)
     if (groups->count < 2) {
         warn("bogus Xref header field in %s", token);
         free(xref);
+        cvector_free(groups);
         return;
     }
 

--- a/backends/innxmit.c
+++ b/backends/innxmit.c
@@ -1121,6 +1121,7 @@ main(int ac, char *av[])
     volatile int port = NNTP_PORT;
     bool val;
     char *path;
+    size_t patharticleslen;
     volatile unsigned int ConnectTimeout;
     volatile unsigned int TotalTimeout;
 
@@ -1130,6 +1131,7 @@ main(int ac, char *av[])
     /* Set defaults. */
     if (!innconf_read(NULL))
         exit(1);
+    patharticleslen = strlen(innconf->patharticles);
 
     ConnectTimeout = 0;
     TotalTimeout = 0;
@@ -1392,11 +1394,10 @@ main(int ac, char *av[])
             continue;
 
         /* Split the line into possibly two fields. */
-        if (Article[0] == '/' && Article[strlen(innconf->patharticles)] == '/'
-            && strncmp(Article, innconf->patharticles,
-                       strlen(innconf->patharticles))
-                   == 0)
-            Article += strlen(innconf->patharticles) + 1;
+        if (Article[0] == '/'
+            && strncmp(Article, innconf->patharticles, patharticleslen) == 0
+            && Article[patharticleslen] == '/')
+            Article += patharticleslen + 1;
         if ((MessageID = strchr(Article, ' ')) != NULL) {
             *MessageID++ = '\0';
             if (*MessageID != '<' || (p = strrchr(MessageID, '>')) == NULL

--- a/backends/ninpaths.c
+++ b/backends/ninpaths.c
@@ -244,8 +244,10 @@ readdump(FILE *f)
                &at)
         != 6)
         formerr(0);
+    if (sit <= 0 || (unsigned long) sit > SIZE_MAX / sizeof(struct nrec *))
+        formerr(0);
 
-    n = calloc(sit, sizeof(struct nrec *));
+    n = calloc((size_t) sit, sizeof(struct nrec *));
     if (!n) {
         fprintf(stderr, "error: out of memory\n");
         goto error;
@@ -266,6 +268,8 @@ readdump(FILE *f)
     if (!strncmp(v, "3.0", 3)) {
         /* Read 3.0-format L-records */
         while (fscanf(f, "%d!%d!%ld ", &a, &b, &l) == 3) {
+            if (a < 0 || a >= sit || b < 0 || b >= sit)
+                formerr(4);
             t = tallyrec(n[a], n[b]);
             if (!t)
                 goto error;
@@ -276,9 +280,11 @@ readdump(FILE *f)
         /* Read L-records */
         while (fscanf(f, " :%d", &a) == 1) {
             while ((i = fscanf(f, "!%d,%ld", &b, &l)) > 0) {
-                t = tallyrec(n[a], n[b]);
                 if (i < 2)
                     l = 1;
+                if (a < 0 || a >= sit || b < 0 || b >= sit)
+                    formerr(4);
+                t = tallyrec(n[a], n[b]);
                 if (!t)
                     goto error;
                 t->tally += l;

--- a/backends/overchan.c
+++ b/backends/overchan.c
@@ -99,11 +99,15 @@ write_overview(struct overview *overview, struct overview_data *data,
     const char *xref = NULL;
 
     statistics->articles++;
-    for (p = data->overview + data->overlen - 1; p > data->overview + 5; p--)
-        if (*p == ':' && strncasecmp(p - 5, "\tXref", 5) == 0) {
-            xref = p + 2;
-            break;
-        }
+    if (data->overlen >= 6)
+        for (p = data->overview + data->overlen - 1;
+             p >= data->overview + 5; p--)
+            if (*p == ':' && strncasecmp(p - 5, "\tXref", 5) == 0) {
+                xref = p + 1;
+                if (xref < data->overview + data->overlen && *xref == ' ')
+                    xref++;
+                break;
+            }
     if (xref == NULL) {
         warn("no Xref found in overview data %s", data->overview);
         return;

--- a/doc/pod/news.pod
+++ b/doc/pod/news.pod
@@ -109,6 +109,16 @@ Support for old insecure OpenSSL and LibreSSL versions have been dropped.
 You will have to use at least S<OpenSSL 1.1.1> or S<LibreSSL 2.8.0>.  Thanks
 to Roman Donchenko for the code simplification and cleaning.
 
+=item *
+
+Hardened several older code paths against memory-safety failures.  This
+includes buffer growth and concatenation in B<innfeed>, IMAP and LMTP
+response parsing, bounded parsing of overview records during expiration,
+validation of corrupt OVDB records and search handles, reserved file
+descriptor management, and hexadecimal and uuencoded data handling.  Reader
+tracking and virtual-host permission state, batch error cleanup, and file-list
+growth in expiration tools were also corrected.
+
 =back
 
 =head1 Changes in 2.7.5 (not yet released)

--- a/expire/expire.c
+++ b/expire/expire.c
@@ -173,9 +173,11 @@ EXPgetnum(int line, char *word, time_t *v, const char *name)
 static bool
 EXPreadfile(FILE *F)
 {
+    char *end;
     char *p;
     int i;
     int j;
+    long storage_class;
     bool SawDefault;
     char buff[BUFSIZ];
     char *fields[7];
@@ -239,9 +241,14 @@ EXPreadfile(FILE *F)
                 j = NUM_STORAGE_CLASSES;
                 SawDefault = true;
             } else {
-                j = atoi(fields[0]);
-                if ((j < 0) || (j >= NUM_STORAGE_CLASSES))
-                    warn("bad storage class %d on line %d", j, i);
+                errno = 0;
+                storage_class = strtol(fields[0], &end, 10);
+                if (errno != 0 || *end != '\0' || storage_class < 0
+                    || storage_class >= NUM_STORAGE_CLASSES) {
+                    warn("bad storage class %s on line %d", fields[0], i);
+                    return false;
+                }
+                j = storage_class;
             }
 
             if (!EXPgetnum(i, fields[1], &EXPclasses[j].Keep, "keep")

--- a/expire/fastrm.c
+++ b/expire/fastrm.c
@@ -114,8 +114,16 @@ static void
 filelist_insert(filelist *list, char *name)
 {
     if (list->count == list->size) {
-        list->size = (list->size == 0) ? 16 : list->size * 2;
-        list->files = xrealloc(list->files, list->size * sizeof(char *));
+        size_t newsize;
+
+        if (list->size == 0)
+            newsize = 16;
+        else if (list->size > INT_MAX / 2)
+            die("file list grew too large");
+        else
+            newsize = (size_t) list->size * 2;
+        list->files = xreallocarray(list->files, newsize, sizeof(char *));
+        list->size = (int) newsize;
     }
     list->files[list->count++] = xstrdup(name);
 }

--- a/expire/makehistory.c
+++ b/expire/makehistory.c
@@ -668,7 +668,7 @@ DoArt(ARTHANDLE *art)
             /* Parse the article only once. */
             if (!hasCounts
                 && (p = wire_findbody(art->data, art->len)) != NULL) {
-                end = art->data + art->len;
+                end = art->data + art->len - 1;
                 /* p is at the beginning of the body, if any. */
                 for (; *p != '\0';) {
                     /* p is at the beginning of a new line, if any. */

--- a/frontends/sys2nf.c
+++ b/frontends/sys2nf.c
@@ -77,7 +77,7 @@ ReadSys(const char *sys)
         continue;
 
     /* Scan the file, glue all multi-line entries. */
-    for (strings = xmalloc((i + 1) * sizeof(char *)), i = 0, to = p = data;
+    for (strings = xmalloc((i + 2) * sizeof(char *)), i = 0, to = p = data;
          *p;) {
         for (site = to; *p;) {
             if (*p == '\n') {

--- a/history/hisv6/hisv6.c
+++ b/history/hisv6/hisv6.c
@@ -51,6 +51,7 @@
 #include "inn/qio.h"
 #include "inn/sequence.h"
 #include "inn/timer.h"
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -101,6 +102,7 @@ hisv6_splitline(const char *line, const char **error, HASH *hash,
 {
     const char *p = line;
     char *end;
+    size_t i;
     unsigned long l;
     int r = 0;
 
@@ -110,13 +112,19 @@ hisv6_splitline(const char *line, const char **error, HASH *hash,
         return -1;
     }
     ++p;
-    if (hash)
-        *hash = TextToHash(p);
-    p += 32;
-    if (*p != ']') {
+    for (i = 0; i < 32; i++) {
+        if (p[i] == '\0' || !isxdigit((unsigned char) p[i])) {
+            *error = "invalid hash in history line";
+            return -1;
+        }
+    }
+    if (p[32] != ']') {
         *error = "`]' missing from history line";
         return -1;
     }
+    if (hash)
+        *hash = TextToHash(p);
+    p += 32;
     ++p;
     r |= HISV6_HAVE_HASH;
     if (*p != HISV6_FIELDSEP) {

--- a/include/inn/buffer.h
+++ b/include/inn/buffer.h
@@ -111,9 +111,10 @@ void buffer_swap(struct buffer *, struct buffer *)
  * Find the given string in the unconsumed data in a buffer.  start is an
  * offset into the unused data specifying where to start the search (to save
  * time with multiple searches).  Pass 0 to start the search at the beginning
- * of the unused data.  Returns true if the terminator is found, putting the
- * offset (into the unused data space) of the beginning of the terminator into
- * the fourth argument.  Returns false if the terminator isn't found.
+ * of the unused data.  The string must be nonempty; an empty string returns
+ * false.  Returns true if the terminator is found, putting the offset (into
+ * the unused data space) of the beginning of the terminator into the fourth
+ * argument.  Returns false if the terminator isn't found.
  */
 bool buffer_find_string(struct buffer *, const char *, size_t start,
                         size_t *offset) __attribute__((__nonnull__));

--- a/include/inn/wire.h
+++ b/include/inn/wire.h
@@ -21,9 +21,9 @@ BEGIN_DECLS
    your article is bodyless). */
 char *wire_findbody(const char *, size_t);
 
-/* Given a pointer into an article and a pointer to the end of the article,
-   find the start of the next line or return NULL if there are no more lines
-   remaining in the article. */
+/* Given a pointer into an article and a pointer to its final octet, find the
+   start of the next line or return NULL if there are no more lines remaining
+   in the article. */
 char *wire_nextline(const char *, const char *end);
 
 /* Given a pointer to the start of an article and the name of a header field,

--- a/innfeed/innlistener.c
+++ b/innfeed/innlistener.c
@@ -432,9 +432,8 @@ newArticleCommand(EndPoint ep, IoStatus i, Buffer *buffs, void *data)
             if (*next == '\r')
                 next++;
 
-            endc--;
-            if (*endc != '\r')
-                endc++;
+            if (endc > cmd && endc[-1] == '\r')
+                endc--;
 
             *endc = '\0';
 

--- a/innfeed/misc.c
+++ b/innfeed/misc.c
@@ -307,9 +307,10 @@ trim_ws(char *string)
     if (len == 0)
         return;
 
-    for (p = string + len - 1; p >= string && isspace((unsigned char) *p); p--)
-        /* nada */;
-    *++p = '\0';
+    p = string + len;
+    while (p > string && isspace((unsigned char) p[-1]))
+        p--;
+    *p = '\0';
 }
 
 

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -82,9 +82,12 @@ buffer_free(struct buffer *buffer)
 void
 buffer_resize(struct buffer *buffer, size_t size)
 {
-    if (size < buffer->size)
+    if (size <= buffer->size)
         return;
-    buffer->size = (size + 1023) & ~1023UL;
+    if (size <= SIZE_MAX - 1023)
+        buffer->size = (size + 1023) & ~((size_t) 1023);
+    else
+        buffer->size = size;
     buffer->data = xrealloc(buffer->data, buffer->size);
 }
 
@@ -151,17 +154,21 @@ buffer_append_vsprintf(struct buffer *buffer, const char *format, va_list args)
     ssize_t status;
     va_list args_copy;
 
+    assert(buffer->used <= SIZE_MAX - buffer->left);
     total = buffer->used + buffer->left;
+    assert(total <= buffer->size);
     avail = buffer->size - total;
     va_copy(args_copy, args);
-    status = vsnprintf(buffer->data + total, avail, format, args_copy);
+    status = vsnprintf(avail > 0 ? buffer->data + total : NULL, avail, format,
+                       args_copy);
     va_end(args_copy);
     if (status < 0)
         return;
     if ((size_t) status < avail) {
         buffer->left += status;
     } else {
-        buffer_resize(buffer, total + status + 1);
+        assert((size_t) status < SIZE_MAX - total);
+        buffer_resize(buffer, total + (size_t) status + 1);
         avail = buffer->size - total;
         status = vsnprintf(buffer->data + total, avail, format, args);
         if (status < 0 || (size_t) status >= avail)
@@ -247,6 +254,8 @@ buffer_find_string(struct buffer *buffer, const char *string, size_t start,
 
     if (buffer->data == NULL)
         return false;
+    if (start > buffer->left || string[0] == '\0')
+        return false;
     length = strlen(string);
     do {
         data = buffer->data + buffer->used + start;
@@ -271,10 +280,17 @@ ssize_t
 buffer_read(struct buffer *buffer, int fd)
 {
     ssize_t count;
+    size_t available, used;
+    void *data;
 
     do {
-        size_t used = buffer->used + buffer->left;
-        count = read(fd, buffer->data + used, buffer->size - used);
+        assert(buffer->used <= SIZE_MAX - buffer->left);
+        used = buffer->used + buffer->left;
+        assert(used <= buffer->size);
+        available = buffer->size - used;
+        data = available > 0 ? buffer->data + used : NULL;
+
+        count = read(fd, data, available);
     } while (count == -1 && (errno == EAGAIN || errno == EINTR));
     if (count > 0)
         buffer->left += count;
@@ -291,13 +307,17 @@ bool
 buffer_read_all(struct buffer *buffer, int fd)
 {
     ssize_t count;
+    size_t size, used;
 
     if (buffer->size == 0)
         buffer_resize(buffer, 1024);
     do {
-        size_t used = buffer->used + buffer->left;
-        if (buffer->size <= used)
-            buffer_resize(buffer, buffer->size * 2);
+        assert(buffer->used <= SIZE_MAX - buffer->left);
+        used = buffer->used + buffer->left;
+        if (buffer->size <= used) {
+            size = buffer->size > SIZE_MAX / 2 ? SIZE_MAX : buffer->size * 2;
+            buffer_resize(buffer, size);
+        }
         count = buffer_read(buffer, fd);
     } while (count > 0);
     return (count == 0);
@@ -315,10 +335,17 @@ bool
 buffer_read_file(struct buffer *buffer, int fd)
 {
     struct stat st;
-    size_t used = buffer->used + buffer->left;
+    size_t used;
+
+    assert(buffer->used <= SIZE_MAX - buffer->left);
+    used = buffer->used + buffer->left;
 
     if (fstat(fd, &st) < 0)
         return false;
-    buffer_resize(buffer, st.st_size + used);
+    if (st.st_size < 0 || (uintmax_t) st.st_size > SIZE_MAX - used) {
+        errno = EOVERFLOW;
+        return false;
+    }
+    buffer_resize(buffer, (size_t) st.st_size + used);
     return buffer_read_all(buffer, fd);
 }

--- a/lib/conffile.c
+++ b/lib/conffile.c
@@ -7,6 +7,8 @@
 #include "conffile.h"
 #include "inn/libinn.h"
 
+static int cfeof(CONFFILE *);
+
 static int
 getconfline(CONFFILE *F, char *buffer, size_t length)
 {
@@ -18,7 +20,9 @@ getconfline(CONFFILE *F, char *buffer, size_t length)
             return 1;
         }
     } else if (F->array) {
-        strlcpy(buffer, F->array[F->lineno], F->sbuf);
+        if (cfeof(F)
+            || strlcpy(buffer, F->array[F->lineno], length) >= length)
+            return 1;
     }
     F->lineno++;
     if (strlen(F->buf) >= F->sbuf - 1) {
@@ -34,7 +38,7 @@ cfeof(CONFFILE *F)
     if (F->f) {
         return feof(F->f);
     } else if (F->array) {
-        return (F->lineno == F->array_len);
+        return (F->lineno >= F->array_len);
     } else {
         return 1;
     }
@@ -145,7 +149,8 @@ CONFfclose(CONFFILE *f)
 {
     if (!f)
         return; /* No conf file */
-    fclose(f->f);
+    if (f->f != NULL)
+        fclose(f->f);
     if (f->buf)
         free(f->buf);
     if (f->filename)

--- a/lib/confparse.c
+++ b/lib/confparse.c
@@ -499,6 +499,11 @@ token_quoted_string(struct config_file *file)
             return;
         case '\\':
             i++;
+            if (file->current[i] == '\0') {
+                offset = file->current - file->buffer;
+                if (!file_read_more(file, offset))
+                    goto unterminated;
+            }
             if (file->current[i] == '\n')
                 file->line++;
 
@@ -517,14 +522,8 @@ token_quoted_string(struct config_file *file)
             status = file_read_more(file, offset);
             if (status)
                 i--;
-            else {
-                warn("%s:%u: end of file encountered while parsing quoted"
-                     " string",
-                     file->filename, file->line);
-                file->token.type = TOKEN_ERROR;
-                file->error = true;
-                return;
-            }
+            else
+                goto unterminated;
 
             /* If the last character of the previous buffer was CR and the
                first character that we just read was LF, the CR must have been
@@ -541,6 +540,13 @@ token_quoted_string(struct config_file *file)
     file->token.type = TOKEN_QSTRING;
     file->token.string = xstrndup(file->current, i);
     file->current += i;
+    return;
+
+unterminated:
+    warn("%s:%u: end of file encountered while parsing quoted string",
+         file->filename, file->line);
+    file->token.type = TOKEN_ERROR;
+    file->error = true;
 }
 
 

--- a/lib/hex.c
+++ b/lib/hex.c
@@ -23,19 +23,17 @@ inn_encode_hex(const unsigned char *data, size_t length, char *buffer,
                size_t buflen)
 {
     static const char hex[] = "0123456789ABCDEF";
-    const unsigned char *p;
-    unsigned int i;
+    size_t input, output;
 
     if (buflen == 0)
         return;
-    for (p = data, i = 0; i < length && (i * 2) < (buflen - 1); p++, i++) {
-        buffer[i * 2] = hex[(*p & 0xf0) >> 4];
-        buffer[(i * 2) + 1] = hex[(*p & 0x0f)];
+    for (input = 0, output = 0; input < length && output < buflen - 1;
+         input++) {
+        buffer[output++] = hex[(data[input] & 0xf0) >> 4];
+        if (output < buflen - 1)
+            buffer[output++] = hex[data[input] & 0x0f];
     }
-    if (length * 2 > buflen - 1)
-        buffer[buflen - 1] = '\0';
-    else
-        buffer[length * 2] = '\0';
+    buffer[output] = '\0';
 }
 
 
@@ -52,7 +50,7 @@ inn_encode_hex(const unsigned char *data, size_t length, char *buffer,
 void
 inn_decode_hex(const char *data, unsigned char *buffer, size_t buflen)
 {
-    unsigned int i;
+    size_t i;
     unsigned char part;
 
     if (buflen == 0)

--- a/lib/wire.c
+++ b/lib/wire.c
@@ -41,7 +41,7 @@ wire_findbody(const char *article, size_t length)
 
     /* Jump from \r to \r and give up if we're too close to the end. */
     end = article + length;
-    for (p = (char *) article; (p + 4) <= end; ++p) {
+    for (p = (char *) article; (size_t) (end - p) >= 4; ++p) {
         p = memchr(p, '\r', end - p - 3);
         if (p == NULL)
             break;
@@ -65,8 +65,10 @@ wire_nextline(const char *article, const char *end)
 {
     char *p;
 
-    for (p = (char *) article; (p + 2) <= end; ++p) {
-        p = memchr(p, '\r', end - p - 2);
+    if (article > end)
+        return NULL;
+    for (p = (char *) article; end - p >= 2; ++p) {
+        p = memchr(p, '\r', end - p - 1);
         if (p == NULL)
             break;
         if (p[1] == '\n') {
@@ -105,7 +107,7 @@ skip_fws_bounded(char *text, const char *end)
     char *p;
 
     for (p = text; p <= end; p++) {
-        if (p < end + 1 && p[0] == '\r' && p[1] == '\n' && ISWHITE(p[2]))
+        if (end - p >= 2 && p[0] == '\r' && p[1] == '\n' && ISWHITE(p[2]))
             p += 2;
         if (!ISWHITE(*p))
             return p;
@@ -131,6 +133,8 @@ wire_findheader(const char *article, size_t length, const char *header,
     ptrdiff_t headerlen;
 
     headerlen = strlen(header);
+    if (length == 0)
+        return NULL;
     end = article + length - 1;
 
     /* There has to be enough space left in the article for at least the

--- a/nnrpd/article.c
+++ b/nnrpd/article.c
@@ -595,9 +595,12 @@ ARTsendmmap(SENDTYPE what)
     if (what == SThead) {
         SendIOv(".\r\n", 3);
         ARTgetsize += 3;
-    } else if (memcmp((ARThandle->data + ARThandle->len - 5), "\r\n.\r\n",
-                      5)) {
-        if (memcmp((ARThandle->data + ARThandle->len - 2), "\r\n", 2)) {
+    } else if (ARThandle->len < 5
+               || memcmp(ARThandle->data + ARThandle->len - 5, "\r\n.\r\n",
+                         5)
+                      != 0) {
+        if (ARThandle->len < 2
+            || memcmp(ARThandle->data + ARThandle->len - 2, "\r\n", 2) != 0) {
             SendIOv("\r\n.\r\n", 5);
             ARTgetsize += 5;
         } else {

--- a/nnrpd/nnrpd.c
+++ b/nnrpd/nnrpd.c
@@ -1429,16 +1429,13 @@ main(int argc, char *argv[])
 
     if ((PERMaccessconf && PERMaccessconf->readertrack)
         || (!PERMaccessconf && innconf->readertrack)) {
-        int len;
         syslog(L_NOTICE, "%s Tracking Enabled (%s)", Client.host, Username);
         pid = getpid();
         gettimeofday(&tv, NULL);
         count += pid;
         vid = tv.tv_sec ^ tv.tv_usec ^ pid ^ count;
-        len = strlen("innconf->pathlog") + strlen("/tracklogs/log-") + BUFSIZ;
-        LocalLogFileName = xmalloc(len);
-        sprintf(LocalLogFileName, "%s/tracklogs/log-%u", innconf->pathlog,
-                vid);
+        xasprintf(&LocalLogFileName, "%s/tracklogs/log-%u", innconf->pathlog,
+                  vid);
         if ((locallog = fopen(LocalLogFileName, "w")) == NULL) {
             LocalLogDirName = concatpath(innconf->pathlog, "tracklogs");
             MakeDirectory(LocalLogDirName, false);

--- a/storage/buffindexed/buffindexed.c
+++ b/storage/buffindexed/buffindexed.c
@@ -730,6 +730,13 @@ ovbuffinit_disks(void)
             strncpy(buf, dpx.totala, OVBUFFLASIZ);
             buf[OVBUFFLASIZ] = '\0';
             ovbuff->totalblk = hex2offt(buf);
+            if (ovbuff->base > ovbuff->len
+                || (off_t) ovbuff->totalblk
+                       != (ovbuff->len - ovbuff->base) / OV_BLOCKSIZE) {
+                warn("buffindexed: invalid block count for %s", ovbuff->path);
+                ovlock(ovbuff, INN_LOCK_UNLOCK);
+                return false;
+            }
 
             if (rpx->version == 0) {
                 /* no binary data available. use character data */
@@ -746,6 +753,12 @@ ovbuffinit_disks(void)
                  */
                 ovbuff->usedblk = rpx->usedblk;
                 ovbuff->freeblk = rpx->freeblk;
+            }
+            if (ovbuff->usedblk > ovbuff->totalblk
+                || ovbuff->freeblk > ovbuff->totalblk) {
+                warn("buffindexed: invalid block usage for %s", ovbuff->path);
+                ovlock(ovbuff, INN_LOCK_UNLOCK);
+                return false;
             }
             Needunlink = false;
         } else {
@@ -865,6 +878,25 @@ getovbuff(OV ov)
             return ovbuff;
     }
     return NULL;
+}
+
+static bool
+ovblockvalid(const OVBUFF *ovbuff, unsigned int blocknum)
+{
+    off_t blocks;
+
+    if (ovbuff->base > ovbuff->len)
+        return false;
+    blocks = (ovbuff->len - ovbuff->base) / OV_BLOCKSIZE;
+    return blocknum < (unsigned long) blocks;
+}
+
+static bool
+ovindexspanvalid(const OVINDEX *index)
+{
+    return index->offset >= 0 && index->len >= 0
+           && index->offset <= OV_BLOCKSIZE
+           && index->len <= OV_BLOCKSIZE - index->offset;
 }
 
 #ifdef OV_DEBUG
@@ -1793,7 +1825,7 @@ ovgroupmmap(GROUPENTRY *ge, ARTNUM low, ARTNUM high, bool needov)
     OV ov = ge->baseindex;
     OVBUFF *ovbuff;
     GROUPDATABLOCK *gdb;
-    int pagefudge, limit, i, count, len;
+    int pagefudge, limit, i, capacity, count, len;
     off_t offset, mmapoffset;
     OVBLOCK *ovblock;
     void *addr;
@@ -1806,14 +1838,25 @@ ovgroupmmap(GROUPENTRY *ge, ARTNUM low, ARTNUM high, bool needov)
     Gibcount = ge->count;
     if (Gibcount == 0)
         return true;
-    Gib = xmalloc(Gibcount * sizeof(OVINDEX));
+    if (Gibcount < 0) {
+        warn("buffindexed: negative overview count");
+        return false;
+    }
+    capacity = Gibcount > OV_FUDGE ? OV_FUDGE : Gibcount;
+    Gib = xmalloc(capacity * sizeof(OVINDEX));
     count = 0;
     while (ov.index != NULLINDEX) {
+        for (giblist = Giblist; giblist != NULL; giblist = giblist->next)
+            if (giblist->ov.index == ov.index
+                && giblist->ov.blocknum == ov.blocknum) {
+                warn("buffindexed: loop in overview index blocks");
+                ovgroupunmap();
+                return false;
+            }
         ovbuff = getovbuff(ov);
-        if (ovbuff == NULL) {
-            warn("buffindexed: ovgroupmmap ovbuff is null(ovindex is %d, "
-                 "ovblock is %u",
-                 ov.index, ov.blocknum);
+        if (ovbuff == NULL || !ovblockvalid(ovbuff, ov.blocknum)) {
+            warn("buffindexed: invalid index block %d:%u", ov.index,
+                 ov.blocknum);
             ovgroupunmap();
             return false;
         }
@@ -1832,13 +1875,25 @@ ovgroupmmap(GROUPENTRY *ge, ARTNUM low, ARTNUM high, bool needov)
         if (ov.index == ge->curindex.index
             && ov.blocknum == ge->curindex.blocknum) {
             limit = ge->curindexoffset;
+            if (limit < 0 || (size_t) limit > OVINDEXMAX) {
+                warn("buffindexed: invalid index entry count %d", limit);
+                munmap(addr, len);
+                ovgroupunmap();
+                return false;
+            }
         } else {
             limit = OVINDEXMAX;
         }
         for (i = 0; i < limit; i++) {
-            if (Gibcount == count) {
-                Gibcount += OV_FUDGE;
-                Gib = xrealloc(Gib, Gibcount * sizeof(OVINDEX));
+            if (capacity == count) {
+                if (capacity > INT_MAX - OV_FUDGE) {
+                    warn("buffindexed: too many overview index entries");
+                    munmap(addr, len);
+                    ovgroupunmap();
+                    return false;
+                }
+                capacity += OV_FUDGE;
+                Gib = xreallocarray(Gib, capacity, sizeof(OVINDEX));
             }
             Gib[count++] = ovblock->ovindex[i];
         }
@@ -1870,7 +1925,7 @@ ovgroupmmap(GROUPENTRY *ge, ARTNUM low, ARTNUM high, bool needov)
         if (gdb != NULL)
             continue;
         ovbuff = getovbuff(ov);
-        if (ovbuff == NULL)
+        if (ovbuff == NULL || !ovblockvalid(ovbuff, ov.blocknum))
             continue;
         gdb = xmalloc(sizeof(GROUPDATABLOCK));
         gdb->datablk = ov;
@@ -1889,11 +1944,9 @@ ovgroupmmap(GROUPENTRY *ge, ARTNUM low, ARTNUM high, bool needov)
         for (gdb = groupdatablock[i]; gdb != NULL; gdb = gdb->next) {
             ov = gdb->datablk;
             ovbuff = getovbuff(ov);
-            if (ovbuff == NULL) {
-                warn("buffindexed: ovgroupmmap could not get ovbuff block for"
-                     " new, %d, %u",
+            if (ovbuff == NULL || !ovblockvalid(ovbuff, ov.blocknum)) {
+                warn("buffindexed: invalid overview data block %d:%u",
                      ov.index, ov.blocknum);
-                free(gdb);
                 ovgroupunmap();
                 return false;
             }
@@ -2005,6 +2058,16 @@ ovsearch(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
             if (artnum)
                 *artnum = Gib[search->cur].artnum;
         } else {
+            srchov.index = Gib[search->cur].index;
+            srchov.blocknum = Gib[search->cur].blocknum;
+            ovbuff = getovbuff(srchov);
+            if (ovbuff == NULL || !ovblockvalid(ovbuff, srchov.blocknum)
+                || !ovindexspanvalid(&Gib[search->cur])) {
+                warn("buffindexed: invalid overview entry for article %lu",
+                     (unsigned long) Gib[search->cur].artnum);
+                search->cur++;
+                return false;
+            }
             if (artnum)
                 *artnum = Gib[search->cur].artnum;
             if (len)
@@ -2014,8 +2077,6 @@ ovsearch(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
             if (expires)
                 *expires = Gib[search->cur].expires;
             if (data) {
-                srchov.index = Gib[search->cur].index;
-                srchov.blocknum = Gib[search->cur].blocknum;
                 gdb = searchgdb(&srchov);
                 if (gdb == NULL) {
                     if (len)
@@ -2039,8 +2100,8 @@ ovsearch(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
                     if (newblock) {
                         search->gdb.datablk.blocknum = srchov.blocknum;
                         search->gdb.datablk.index = srchov.index;
-                        ovbuff = getovbuff(srchov);
-                        if (ovbuff == NULL) {
+                        if (ovbuff == NULL
+                            || !ovblockvalid(ovbuff, srchov.blocknum)) {
                             warn("buffindexed: ovsearch could not get ovbuff"
                                  " block for new, %d, %u",
                                  srchov.index, srchov.blocknum);

--- a/storage/cnfs/cnfs.c
+++ b/storage/cnfs/cnfs.c
@@ -69,6 +69,29 @@ static int refresh_interval = REFRESH_INTERVAL;
 
 static CYCBUFF *CNFSgetcycbuffbyname(char *name);
 
+static bool
+CNFSReadFully(int fd, void *buffer, size_t length, off_t offset)
+{
+    char *p = buffer;
+
+    while (length > 0) {
+        ssize_t count;
+
+        do {
+            count = pread(fd, p, length, offset);
+        } while (count < 0 && errno == EINTR);
+        if (count <= 0) {
+            if (count == 0)
+                errno = EIO;
+            return false;
+        }
+        p += count;
+        length -= count;
+        offset += count;
+    }
+    return true;
+}
+
 
 /*
 **  The token is @03nnxxxxxxxxxxxxxxxxyyyyyyyyzzzzzzzz@
@@ -1584,7 +1607,8 @@ cnfs_retrieve(const TOKEN token, const RETRTYPE amount)
     } else {
         private->base = xmalloc(ntohl(cah.size));
         pagefudge = 0;
-        if (pread(cycbuff->fd, private->base, ntohl(cah.size), offset) < 0) {
+        if (!CNFSReadFully(cycbuff->fd, private->base, ntohl(cah.size),
+                           offset)) {
             SMseterror(SMERR_UNDEFINED, "read failed");
             syswarn("CNFS: could not read token %s %s:0x%s:%u",
                     TokenToText(token), cycbuffname,
@@ -1979,7 +2003,8 @@ cnfs_next(ARTHANDLE *article, const RETRTYPE amount)
     } else {
         private->base = xmalloc(ntohl(cah.size));
         pagefudge = 0;
-        if (pread(cycbuff->fd, private->base, ntohl(cah.size), offset) < 0) {
+        if (!CNFSReadFully(cycbuff->fd, private->base, ntohl(cah.size),
+                           offset)) {
             art->data = NULL;
             art->len = 0;
             art->token = NULL;

--- a/storage/expire.c
+++ b/storage/expire.c
@@ -170,19 +170,21 @@ EXPsplit(char *p, char sep, char **argv, int count)
     if (*p == '\0')
         return 0;
 
-    for (i = 1, *argv++ = p; *p;)
-        if (*p++ == sep) {
-            p[-1] = '\0';
-            for (; *p == sep; p++)
-                ;
-            if (!*p)
-                return i;
-            if (++i == count)
-                /* Overflow. */
-                return -1;
-            *argv++ = p;
-        }
-    return i;
+    i = 0;
+    for (;;) {
+        if (i >= count)
+            return -1;
+        argv[i++] = p;
+        while (*p != '\0' && *p != sep)
+            p++;
+        if (*p == '\0')
+            return i;
+        *p++ = '\0';
+        while (*p == sep)
+            p++;
+        if (*p == '\0')
+            return i;
+    }
 }
 
 /*

--- a/storage/expire.c
+++ b/storage/expire.c
@@ -365,7 +365,8 @@ EXPreadfile(FILE *F)
             *p = '\0';
         else
             p = buff + strlen(buff);
-        while (--p >= buff) {
+        while (p > buff) {
+            p--;
             if (isspace((unsigned char) *p))
                 *p = '\0';
             else
@@ -375,6 +376,11 @@ EXPreadfile(FILE *F)
             continue;
         if ((j = EXPsplit(buff, ':', fields, ARRAY_SIZE(fields))) == -1) {
             fprintf(stderr, "Line %d too many fields\n", i);
+            free(patterns);
+            return false;
+        }
+        if (j == 0) {
+            fprintf(stderr, "Line %d bad format\n", i);
             free(patterns);
             return false;
         }
@@ -697,6 +703,11 @@ OVfindheaderindex(void)
         krps = xmalloc(nGroups * sizeof(enum KRP));
         path = concatpath(innconf->pathetc, INN_PATH_EXPIRECTL);
         F = fopen(path, "r");
+        if (F == NULL) {
+            fprintf(stderr, "Can't read %s, %s\n", path, strerror(errno));
+            free(path);
+            exit(1);
+        }
         free(path);
         if (!EXPreadfile(F)) {
             fclose(F);

--- a/storage/ovdb/ovdb.c
+++ b/storage/ovdb/ovdb.c
@@ -785,7 +785,8 @@ groupid_new(group_id_t *gno, DB_TXN *tid)
         }
     }
 
-    if (val.size % sizeof(group_id_t)) {
+    if (val.size < sizeof(group_id_t)
+        || val.size % sizeof(group_id_t) != 0) {
         warn("OVDB: invalid size (%u) for !groupid_freelist", val.size);
         return EINVAL;
     }
@@ -834,7 +835,8 @@ groupid_free(group_id_t gno, DB_TXN *tid)
         return ret;
     }
 
-    if (val.size % sizeof(group_id_t)) {
+    if (val.size < sizeof(group_id_t)
+        || val.size % sizeof(group_id_t) != 0) {
         warn("OVDB: invalid size (%u) for !groupid_freelist", val.size);
         return EINVAL;
     }
@@ -1097,7 +1099,7 @@ delete_old_stuff(int forgotton)
 
     while ((ret = cursor->c_get(cursor, &key, &val, DB_NEXT)) == 0) {
         if (key.size == sizeof("!groupid_freelist")
-            && !strcmp("!groupid_freelist", key.data))
+            && memcmp("!groupid_freelist", key.data, key.size) == 0)
             continue;
         if (val.size != sizeof(struct groupinfo)) {
             warn("OVDB: delete_old_stuff: wrong size for groupinfo record");
@@ -2177,24 +2179,32 @@ myuncompress(char *buf, size_t buflen, size_t *newlen)
     uint32_t sz;
     int ret;
 
+    if (buflen <= sizeof(sz)) {
+        warn("OVDB: compressed value is truncated");
+        return NULL;
+    }
+
     memcpy(&sz, buf, sizeof(sz));
     sz = ntohl(sz);
+    if (sz == 0 || sz > MAX_UNZIP_SZ) {
+        warn("OVDB: compressed value has bogus size: %u", sz);
+        return NULL;
+    }
 
     if (sz >= dbuflen) {
-        if (dbuflen == 0) {
-            dbuflen = sz + 512;
+        dbuflen = sz + 1;
+        if (dbuf == NULL) {
             dbuf = xmalloc(dbuflen);
         } else {
-            dbuflen = sz + 512;
             dbuf = xrealloc(dbuf, dbuflen);
         }
     }
-    ulen = dbuflen - 1;
+    ulen = sz;
 
     ret = uncompress((Bytef *) dbuf, &ulen, (Bytef *) (buf + sizeof(uint32_t)),
                      buflen - sizeof(uint32_t));
-    if (ret != Z_OK) {
-        warn("OVDB: uncompress failed");
+    if (ret != Z_OK || ulen != sz) {
+        warn("OVDB: uncompress failed or returned the wrong size");
         return NULL;
     }
     dbuf[ulen] = 0; /* paranoia */
@@ -2304,14 +2314,14 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
     struct ovdata ovd;
     uint32_t sz = 0;
     struct datakey dk;
-    int ret;
+    int i, ret;
     char *dp;
 
     if (clientmode) {
         struct rs_cmd rs;
         struct rs_srch repl;
         static char *databuf;
-        static int buflen = 0;
+        static size_t buflen = 0;
 
         rs.what = CMD_SRCH;
         rs.handle = handle;
@@ -2321,18 +2331,18 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
         if (crecv(&repl, sizeof(repl)) < 0)
             return false;
 
-        if (repl.status != CMD_SRCH)
+        if (repl.status != CMD_SRCH || repl.len < 0)
             return false;
-        if (repl.len > buflen) {
-            if (buflen == 0) {
-                buflen = repl.len + 512;
+        if ((size_t) repl.len > buflen) {
+            buflen = repl.len;
+            if (databuf == NULL) {
                 databuf = xmalloc(buflen);
             } else {
-                buflen = repl.len + 512;
                 databuf = xrealloc(databuf, buflen);
             }
         }
-        crecv(databuf, repl.len);
+        if (repl.len > 0 && crecv(databuf, repl.len) < 0)
+            return false;
 
         if (artnum)
             *artnum = repl.artnum;
@@ -2345,6 +2355,14 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
         if (data)
             *data = databuf;
         return true;
+    }
+
+    for (i = 0; i < nsearches; i++)
+        if (s == searches[i])
+            break;
+    if (i == nsearches) {
+        warn("OVDB: search: invalid search handle");
+        return false;
     }
 
     switch (s->state) {
@@ -2418,6 +2436,14 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
         s->cursor = NULL;
         return false;
     }
+    if ((len || data)
+        && val.size - sizeof(struct ovdata) > (size_t) INT_MAX) {
+        warn("OVDB: search: value is too large");
+        s->state = 3;
+        s->cursor->c_close(s->cursor);
+        s->cursor = NULL;
+        return false;
+    }
 
     if (ntohl(dk.artnum) == s->lastart) {
         s->state = 2;
@@ -2441,9 +2467,14 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
         /* data is compressed */
         memcpy(&sz, dp, sizeof(uint32_t));
         sz = ntohl(sz);
-        if (sz > MAX_UNZIP_SZ) { /* sanity check */
+        if (sz == 0 || sz > MAX_UNZIP_SZ) { /* sanity check */
             warn("OVDB: search: bogus sz: %u", sz);
-            sz = 0;
+            s->state = 3;
+            if (s->cursor != NULL) {
+                s->cursor->c_close(s->cursor);
+                s->cursor = NULL;
+            }
+            return false;
         }
     }
 #    endif
@@ -2458,12 +2489,14 @@ ovdb_search(void *handle, ARTNUM *artnum, char **data, int *len, TOKEN *token,
 
     if (data) {
 #    ifdef HAVE_ZLIB
-        if (sz && val.size > sizeof(struct ovdata) + sizeof(uint32_t)) {
+        if (sz) {
             *data = myuncompress(dp, val.size - sizeof(struct ovdata), NULL);
             if (*data == NULL) {
                 s->state = 3;
-                s->cursor->c_close(s->cursor);
-                s->cursor = NULL;
+                if (s->cursor != NULL) {
+                    s->cursor->c_close(s->cursor);
+                    s->cursor = NULL;
+                }
                 return false;
             }
         } else
@@ -2488,14 +2521,18 @@ ovdb_closesearch(void *handle)
     } else {
         struct ovdbsearch *s = (struct ovdbsearch *) handle;
 
+        for (i = 0; i < nsearches; i++) {
+            if (s == searches[i])
+                break;
+        }
+        if (i == nsearches) {
+            warn("OVDB: closesearch: invalid search handle");
+            return;
+        }
+
         if (s->cursor)
             s->cursor->c_close(s->cursor);
 
-        for (i = 0; i < nsearches; i++) {
-            if (s == searches[i]) {
-                break;
-            }
-        }
         nsearches--;
         for (; i < nsearches; i++) {
             searches[i] = searches[i + 1];
@@ -2863,7 +2900,7 @@ ovdb_expiregroup(const char *group, int *lo, struct history *h)
                 char *p = (char *) val.data + sizeof(ovd);
                 size_t sz = val.size - sizeof(ovd);
 #    ifdef HAVE_ZLIB
-                if (*p == 0)
+                if (sz > sizeof(uint32_t) && *p == 0)
                     p = myuncompress(p, sz, &sz);
                 if (p == NULL) {
                     p = (char *) "";

--- a/storage/timecaf/caf.c
+++ b/storage/timecaf/caf.c
@@ -636,12 +636,18 @@ CAFOpenArtRead(const char *path, ARTNUM art, size_t *len)
     /* I'm not sure if this fstat is worth the speed hit, but unless we check
        here, we may simply segfault when we try to access mmap'd space beyond
        the end of the file.  I think robustness wins. */
-    if (fstat(fd, &st) == 0)
-        if (tocent.Size + tocent.Offset > (size_t) st.st_size) {
-            CAFError(CAF_ERR_IO);
-            close(fd);
-            return -1;
-        }
+    if (fstat(fd, &st) < 0) {
+        CAFError(CAF_ERR_IO);
+        close(fd);
+        return -1;
+    }
+    if (st.st_size < 0 || tocent.Offset < 0
+        || tocent.Size > (size_t) st.st_size
+        || (size_t) tocent.Offset > (size_t) st.st_size - tocent.Size) {
+        CAFError(CAF_ERR_BADFILE);
+        close(fd);
+        return -1;
+    }
 
     *len = tocent.Size;
     return fd;
@@ -1150,7 +1156,7 @@ int
 CAFOpenReadTOC(char *path, CAFHEADER *ch, CAFTOCENT **tocpp)
 {
     int fd;
-    int nb;
+    size_t count, nb;
     CAFTOCENT *tocp;
     off_t offset;
 
@@ -1174,19 +1180,30 @@ CAFOpenReadTOC(char *path, CAFHEADER *ch, CAFTOCENT **tocpp)
     }
 
     /* Allocate memory for TOC. */
-    tocp = xmalloc((ch->High - ch->Low + 1) * sizeof(CAFTOCENT));
-    nb = (sizeof(CAFTOCENT))
-         * (ch->High - ch->Low + 1); /* # bytes to read for toc. */
+    if (ch->High < ch->Low
+        || ch->High - ch->Low >= ch->NumSlots
+        || ch->High - ch->Low + 1 > SIZE_MAX / sizeof(CAFTOCENT)) {
+        CAFError(CAF_ERR_BADFILE);
+        close(fd);
+        return -1;
+    }
+    count = ch->High - ch->Low + 1;
+    nb = sizeof(CAFTOCENT) * count;
+    tocp = xmalloc(nb);
 
     /* seek to beginning of TOC */
     offset = sizeof(CAFHEADER) + ch->FreeZoneTabSize;
 
     if (lseek(fd, offset, SEEK_SET) < 0) {
         CAFError(CAF_ERR_IO);
+        free(tocp);
+        close(fd);
         return -1;
     }
 
     if (OurRead(fd, tocp, nb) < 0) {
+        free(tocp);
+        close(fd);
         return -1;
     }
 
@@ -1312,9 +1329,11 @@ CAFRemoveMultArts(char *path, unsigned int narts, ARTNUM *artnums)
     /* need to update header. */
     if (lseek(fd, 0, SEEK_SET) < 0) {
         CAFError(CAF_ERR_IO);
+        close(fd);
         return -1;
     }
     if (OurWrite(fd, &head, sizeof(CAFHEADER)) < 0) {
+        close(fd);
         return -1;
     }
 

--- a/storage/timecaf/timecaf.c
+++ b/storage/timecaf/timecaf.c
@@ -455,6 +455,8 @@ timecaf_store(const ARTHANDLE article, const STORAGECLASS class)
                  CAFErrorStr());
             SMseterror(SMERR_UNDEFINED, NULL);
             free(path);
+            WritingFile.path = NULL;
+            WritingFile.fd = -1;
             token.type = TOKEN_EMPTY;
             return token;
         }
@@ -578,7 +580,7 @@ OpenArticle(const char *path, ARTNUM artnum, const RETRTYPE amount)
 
     if ((p = wire_findbody(private->artdata, private->artlen)) == NULL) {
         SMseterror(SMERR_NOBODY, NULL);
-        if (innconf->articlemmap)
+        if (innconf->articlemmap && private->mmapbase != NULL)
             munmap(private->mmapbase, private->mmaplen);
         else
             free(private->artdata);
@@ -829,7 +831,7 @@ timecaf_next(ARTHANDLE *article, const RETRTYPE amount)
         priv = *(PRIV_TIMECAF *) article->private;
         free(article->private);
         free(article);
-        if (innconf->articlemmap)
+        if (innconf->articlemmap && priv.mmapbase != NULL)
             munmap(priv.mmapbase, priv.mmaplen);
         else
             free(priv.artdata);
@@ -901,7 +903,7 @@ timecaf_next(ARTHANDLE *article, const RETRTYPE amount)
         art->type = TOKEN_TIMECAF;
         art->data = NULL;
         art->len = 0;
-        art->private = xmalloc(sizeof(PRIV_TIMECAF));
+        art->private = xcalloc(1, sizeof(PRIV_TIMECAF));
     }
     newpriv = (PRIV_TIMECAF *) art->private;
     newpriv->top = priv.top;

--- a/storage/timecaf/timecaf.c
+++ b/storage/timecaf/timecaf.c
@@ -526,20 +526,43 @@ OpenArticle(const char *path, ARTNUM artnum, const RETRTYPE amount)
 
     private = xmalloc(sizeof(PRIV_TIMECAF));
     art->private = (void *) private;
+    if (len > UINT_MAX) {
+        SMseterror(SMERR_UNDEFINED, "article is too large");
+        close(fd);
+        free(art->private);
+        free(art);
+        return NULL;
+    }
     private->artlen = len;
     if (innconf->articlemmap) {
         off_t curoff, tmpoff;
         size_t delta;
 
         curoff = lseek(fd, (off_t) 0, SEEK_CUR);
+        if (curoff < 0) {
+            SMseterror(SMERR_UNDEFINED, NULL);
+            syswarn("timecaf: could not locate article");
+            close(fd);
+            free(art->private);
+            free(art);
+            return NULL;
+        }
         delta = curoff % pagesize;
         tmpoff = curoff - delta;
+        if (len > SIZE_MAX - delta) {
+            SMseterror(SMERR_UNDEFINED, "article mapping is too large");
+            close(fd);
+            free(art->private);
+            free(art);
+            return NULL;
+        }
         private->mmaplen = len + delta;
         if ((private->mmapbase = mmap(NULL, private->mmaplen, PROT_READ,
                                       MAP_SHARED, fd, tmpoff))
             == MAP_FAILED) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("timecaf: could not mmap article");
+            close(fd);
             free(art->private);
             free(art);
             return NULL;
@@ -552,9 +575,10 @@ OpenArticle(const char *path, ARTNUM artnum, const RETRTYPE amount)
         private->artdata = private->mmapbase + delta;
     } else {
         private->artdata = xmalloc(private->artlen);
-        if (read(fd, private->artdata, private->artlen) < 0) {
+        if (xread(fd, private->artdata, private->artlen) < 0) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("timecaf: could not read article");
+            close(fd);
             free(private->artdata);
             free(art->private);
             free(art);
@@ -598,8 +622,8 @@ OpenArticle(const char *path, ARTNUM artnum, const RETRTYPE amount)
     }
 
     if (amount == RETR_BODY) {
-        art->data = p + 4;
-        art->len = art->len - (private->artdata - p - 4);
+        art->data = p;
+        art->len = private->artlen - (p - private->artdata);
         return art;
     }
     SMseterror(SMERR_UNDEFINED, "Invalid retrieve request");
@@ -819,7 +843,9 @@ timecaf_next(ARTHANDLE *article, const RETRTYPE amount)
 
     length = strlen(innconf->patharticles) + 32;
     path = xmalloc(length);
-    if (article == NULL) {
+    if (article == NULL || article->private == NULL) {
+        if (article != NULL)
+            free(article);
         priv.top = NULL;
         priv.sec = NULL;
         priv.ter = NULL;
@@ -903,6 +929,8 @@ timecaf_next(ARTHANDLE *article, const RETRTYPE amount)
         art->type = TOKEN_TIMECAF;
         art->data = NULL;
         art->len = 0;
+        art->private = xcalloc(1, sizeof(PRIV_TIMECAF));
+    } else if (art->private == NULL) {
         art->private = xcalloc(1, sizeof(PRIV_TIMECAF));
     }
     newpriv = (PRIV_TIMECAF *) art->private;

--- a/storage/timehash/timehash.c
+++ b/storage/timehash/timehash.c
@@ -272,6 +272,13 @@ OpenArticle(const char *path, RETRTYPE amount)
     if (fstat(fd, &sb) < 0) {
         SMseterror(SMERR_UNDEFINED, NULL);
         syswarn("timehash: could not fstat article");
+        close(fd);
+        free(art);
+        return NULL;
+    }
+    if (sb.st_size < 0 || sb.st_size > INT_MAX) {
+        SMseterror(SMERR_UNDEFINED, "article is too large");
+        close(fd);
         free(art);
         return NULL;
     }
@@ -285,6 +292,7 @@ OpenArticle(const char *path, RETRTYPE amount)
             == MAP_FAILED) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("timehash: could not mmap article");
+            close(fd);
             free(art->private);
             free(art);
             return NULL;
@@ -295,9 +303,10 @@ OpenArticle(const char *path, RETRTYPE amount)
             madvise(private->base, sb.st_size, MADV_SEQUENTIAL);
     } else {
         private->base = xmalloc(private->len);
-        if (read(fd, private->base, private->len) < 0) {
+        if (xread(fd, private->base, private->len) < 0) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("timehash: could not read article");
+            close(fd);
             free(private->base);
             free(art->private);
             free(art);
@@ -475,7 +484,9 @@ timehash_next(ARTHANDLE *article, const RETRTYPE amount)
 
     length = strlen(innconf->patharticles) + 32;
     path = xmalloc(length);
-    if (article == NULL) {
+    if (article == NULL || article->private == NULL) {
+        if (article != NULL)
+            free(article);
         priv.top = NULL;
         priv.sec = NULL;
         priv.ter = NULL;
@@ -566,6 +577,8 @@ timehash_next(ARTHANDLE *article, const RETRTYPE amount)
         art->private = xmalloc(sizeof(PRIV_TIMEHASH));
         newpriv = (PRIV_TIMEHASH *) art->private;
         newpriv->base = NULL;
+    } else if (art->private == NULL) {
+        art->private = xcalloc(1, sizeof(PRIV_TIMEHASH));
     }
     newpriv = (PRIV_TIMEHASH *) art->private;
     newpriv->top = priv.top;

--- a/storage/tradindexed/tdx-data.c
+++ b/storage/tradindexed/tdx-data.c
@@ -177,6 +177,7 @@ file_open_index(struct group_data *data, const char *suffix)
     if (fstat(data->indexfd, &st) < 0) {
         syswarn("tradindexed: cannot stat %s.%s", data->path, suffix);
         close(data->indexfd);
+        data->indexfd = -1;
         return false;
     }
     data->indexinode = st.st_ino;
@@ -249,10 +250,14 @@ tdx_data_open_files(struct group_data *data)
     return true;
 
 fail:
-    if (data->indexfd >= 0)
+    if (data->indexfd >= 0) {
         close(data->indexfd);
-    if (data->datafd >= 0)
+        data->indexfd = -1;
+    }
+    if (data->datafd >= 0) {
         close(data->datafd);
+        data->datafd = -1;
+    }
     return false;
 }
 
@@ -303,7 +308,12 @@ map_index(struct group_data *data)
     r = fstat(data->indexfd, &st);
     if (r == -1) {
         if (errno == ESTALE) {
-            r = file_open_index(data, NULL);
+            if (!file_open_index(data, NULL))
+                return false;
+            r = fstat(data->indexfd, &st);
+            if (r == -1)
+                syswarn("tradindexed: cannot stat reopened %s.IDX",
+                        data->path);
         } else {
             syswarn("tradindexed: cannot stat %s.IDX", data->path);
         }
@@ -328,7 +338,12 @@ map_data(struct group_data *data)
     r = fstat(data->datafd, &st);
     if (r == -1) {
         if (errno == ESTALE) {
-            r = file_open_data(data, NULL);
+            if (!file_open_data(data, NULL))
+                return false;
+            r = fstat(data->datafd, &st);
+            if (r == -1)
+                syswarn("tradindexed: cannot stat reopened %s.DAT",
+                        data->path);
         } else {
             syswarn("tradindexed: cannot stat %s.DAT", data->path);
         }
@@ -337,7 +352,7 @@ map_data(struct group_data *data)
         return false;
     data->datalen = st.st_size;
     data->data = map_file(data->datafd, data->datalen, data->path, "DAT");
-    return (data->data == NULL && data->indexlen > 0) ? false : true;
+    return (data->data == NULL && data->datalen > 0) ? false : true;
 }
 
 
@@ -501,14 +516,17 @@ bool
 tdx_search(struct search *search, struct article *artdata)
 {
     struct index_entry *entry;
-    size_t max;
+    size_t count, max;
 
     if (search == NULL || search->data == NULL)
         return false;
     if (search->data->index == NULL || search->data->data == NULL)
         return false;
 
-    max = (search->data->indexlen / sizeof(struct index_entry)) - 1;
+    count = search->data->indexlen / sizeof(struct index_entry);
+    if (search->current >= count)
+        return false;
+    max = count - 1;
     entry = search->data->index + search->current;
     while (search->current <= search->limit && search->current <= max) {
         if (entry->length != 0)
@@ -525,7 +543,10 @@ tdx_search(struct search *search, struct article *artdata)
        seems not to be an issue in limited testing, although write caching
        that leads to on-disk IDX and DAT being out of sync could trigger a
        problem here. */
-    if (entry->offset + entry->length > search->data->datalen) {
+    if (entry->offset < 0 || entry->length < 0
+        || (size_t) entry->offset > search->data->datalen
+        || (size_t) entry->length
+               > search->data->datalen - (size_t) entry->offset) {
         search->data->remapoutoforder = true;
         warn("Invalid or inaccessible entry for article %lu in %s.IDX:"
              " offset %lu length %lu datalength %lu",
@@ -995,7 +1016,8 @@ entry_audit(struct group_data *data, struct index_entry *entry,
             goto clear;
         return;
     }
-    if (entry->offset > data->datalen || entry->length > data->datalen) {
+    if (entry->offset < 0 || (size_t) entry->offset > data->datalen
+        || (size_t) entry->length > data->datalen) {
         warn("tradindexed: offset %lu or length %lu out of bounds for %s:%lu",
              (unsigned long) entry->offset, (unsigned long) entry->length,
              group, article);
@@ -1003,7 +1025,7 @@ entry_audit(struct group_data *data, struct index_entry *entry,
             goto clear;
         return;
     }
-    if (entry->offset + entry->length > data->datalen) {
+    if ((size_t) entry->length > data->datalen - (size_t) entry->offset) {
         warn("tradindexed: offset %lu plus length %lu out of bounds for"
              " %s:%lu",
              (unsigned long) entry->offset, (unsigned long) entry->length,

--- a/storage/tradindexed/tdx-data.c
+++ b/storage/tradindexed/tdx-data.c
@@ -544,9 +544,9 @@ tdx_search(struct search *search, struct article *artdata)
        that leads to on-disk IDX and DAT being out of sync could trigger a
        problem here. */
     if (entry->offset < 0 || entry->length < 0
-        || (size_t) entry->offset > search->data->datalen
-        || (size_t) entry->length
-               > search->data->datalen - (size_t) entry->offset) {
+        || entry->offset > search->data->datalen
+        || (off_t) entry->length
+               > search->data->datalen - entry->offset) {
         search->data->remapoutoforder = true;
         warn("Invalid or inaccessible entry for article %lu in %s.IDX:"
              " offset %lu length %lu datalength %lu",
@@ -724,21 +724,22 @@ tdx_data_pack_start(struct group_data *data, ARTNUM artnum)
         goto fail;
     }
     if (close(fd) < 0) {
+        fd = -1;
         syswarn("tradindexed: cannot close %s.IDX-NEW", data->path);
         goto fail;
     }
+    fd = -1;
     data->base = base;
     data->indexinode = st.st_ino;
     return true;
 
 fail:
-    if (fd >= 0) {
+    if (fd >= 0)
         close(fd);
-        idxfile = concat(data->path, ".IDX-NEW", (char *) 0);
-        if (unlink(idxfile) < 0)
-            syswarn("tradindexed: cannot unlink %s", idxfile);
-        free(idxfile);
-    }
+    idxfile = concat(data->path, ".IDX-NEW", (char *) 0);
+    if (unlink(idxfile) < 0)
+        syswarn("tradindexed: cannot unlink %s", idxfile);
+    free(idxfile);
     return false;
 }
 
@@ -865,7 +866,7 @@ tdx_data_expire_start(const char *group, struct group_data *data,
                       struct group_entry *index, struct history *history)
 {
     struct group_data *new_data;
-    struct search *search;
+    struct search *search = NULL;
     struct article article;
     ARTNUM high;
 
@@ -878,9 +879,12 @@ tdx_data_expire_start(const char *group, struct group_data *data,
        so that we can treat all errors on opening a search as errors. */
     high = index->high > 0 ? index->high : data->base;
     new_data->high = high;
+    data->refcount++;
     search = tdx_search_open(data, data->base, high, high);
-    if (search == NULL)
+    if (search == NULL) {
+        data->refcount--;
         goto fail;
+    }
 
     /* Loop through all of the articles in the group, adding the ones that are
        still valid to the new index. */
@@ -913,10 +917,16 @@ tdx_data_expire_start(const char *group, struct group_data *data,
     }
 
     /* Done; the rest happens in tdx_data_rebuild_finish. */
+    tdx_search_close(search);
+    data->refcount--;
     tdx_data_close(new_data);
     return true;
 
 fail:
+    if (search != NULL) {
+        tdx_search_close(search);
+        data->refcount--;
+    }
     tdx_data_delete(group, "-NEW");
     tdx_data_close(new_data);
     return false;
@@ -1016,8 +1026,8 @@ entry_audit(struct group_data *data, struct index_entry *entry,
             goto clear;
         return;
     }
-    if (entry->offset < 0 || (size_t) entry->offset > data->datalen
-        || (size_t) entry->length > data->datalen) {
+    if (entry->offset < 0 || entry->offset > data->datalen
+        || (off_t) entry->length > data->datalen) {
         warn("tradindexed: offset %lu or length %lu out of bounds for %s:%lu",
              (unsigned long) entry->offset, (unsigned long) entry->length,
              group, article);
@@ -1025,7 +1035,7 @@ entry_audit(struct group_data *data, struct index_entry *entry,
             goto clear;
         return;
     }
-    if ((size_t) entry->length > data->datalen - (size_t) entry->offset) {
+    if ((off_t) entry->length > data->datalen - entry->offset) {
         warn("tradindexed: offset %lu plus length %lu out of bounds for"
              " %s:%lu",
              (unsigned long) entry->offset, (unsigned long) entry->length,
@@ -1069,8 +1079,10 @@ tdx_data_audit(const char *group, struct group_entry *index, bool fix)
     bool changed = false;
 
     data = tdx_data_new(group, true);
-    if (!tdx_data_open_files(data))
+    if (!tdx_data_open_files(data)) {
+        tdx_data_close(data);
         return;
+    }
     if (!map_index(data))
         goto end;
     if (!map_data(data))

--- a/storage/tradindexed/tdx-group.c
+++ b/storage/tradindexed/tdx-group.c
@@ -495,7 +495,7 @@ static long
 index_find(struct group_index *index, const char *group)
 {
     HASH hash;
-    long loc;
+    long loc, steps;
 
     if (index->header == NULL || index->entries == NULL)
         return -1;
@@ -504,9 +504,13 @@ index_find(struct group_index *index, const char *group)
         return -1;
     loc = index->header->hash[index_bucket(hash)].recno;
 
-    while (loc >= 0) {
+    for (steps = 0; loc >= 0; steps++) {
         struct group_entry *entry;
 
+        if (steps >= index->count) {
+            warn("tradindexed: loop in group index");
+            return -1;
+        }
         if (loc >= index->count) {
             if (!index_maybe_remap(index, loc)) {
                 return -1;
@@ -526,6 +530,8 @@ index_find(struct group_index *index, const char *group)
         }
         loc = entry->next.recno;
     }
+    if (loc != -1)
+        warn("tradindexed: invalid negative index %ld", loc);
     return -1;
 }
 
@@ -553,14 +559,18 @@ static long
 index_unlink_hash(struct group_index *index, HASH hash)
 {
     int *parent;
-    long current;
+    long current, steps;
 
     parent = &index->header->hash[index_bucket(hash)].recno;
     current = *parent;
 
-    while (current >= 0) {
+    for (steps = 0; current >= 0; steps++) {
         struct group_entry *entry;
 
+        if (steps >= index->count) {
+            warn("tradindexed: loop in group index");
+            return -1;
+        }
         if (current >= index->count) {
             if (!index_maybe_remap(index, current)) {
                 return -1;
@@ -585,6 +595,8 @@ index_unlink_hash(struct group_index *index, HASH hash)
         parent = &entry->next.recno;
         current = *parent;
     }
+    if (current != -1)
+        warn("tradindexed: invalid negative index %ld", current);
     return -1;
 }
 
@@ -662,6 +674,13 @@ tdx_index_add(struct group_index *index, const char *group, ARTNUM low,
             return false;
         }
     loc = index->header->freelist.recno;
+    if (loc < 0 || loc >= index->count
+        || index->entries[loc].next.recno < -1
+        || index->entries[loc].next.recno >= index->count) {
+        warn("tradindexed: invalid free list entry %ld", loc);
+        index_lock(index->fd, INN_LOCK_UNLOCK);
+        return false;
+    }
     index->header->freelist.recno = index->entries[loc].next.recno;
     inn_msync_page(&index->header->freelist, sizeof(struct loc), MS_ASYNC);
 
@@ -1131,7 +1150,7 @@ void
 tdx_index_dump(struct group_index *index, FILE *output)
 {
     int bucket;
-    long current;
+    long current, steps;
     struct group_entry *entry;
     struct hash *hashmap;
     struct hashmap *group;
@@ -1142,9 +1161,16 @@ tdx_index_dump(struct group_index *index, FILE *output)
     hashmap = hashmap_load();
     for (bucket = 0; bucket < TDX_HASH_SIZE; bucket++) {
         current = index->header->hash[bucket].recno;
-        while (current != -1) {
-            if (!index_maybe_remap(index, current))
-                return;
+        for (steps = 0; current >= 0; steps++) {
+            if (steps >= index->count) {
+                warn("tradindexed: loop in group index bucket %d", bucket);
+                goto done;
+            }
+            if (!index_maybe_remap(index, current)
+                || current >= index->count) {
+                warn("tradindexed: entry %ld out of range", current);
+                goto done;
+            }
             entry = index->entries + current;
             name = NULL;
             if (hashmap != NULL) {
@@ -1157,11 +1183,16 @@ tdx_index_dump(struct group_index *index, FILE *output)
             tdx_index_print(name, entry, output);
             if (current == entry->next.recno) {
                 warn("tradindexed: index loop for entry %ld", current);
-                return;
+                goto done;
             }
             current = entry->next.recno;
         }
+        if (current != -1) {
+            warn("tradindexed: invalid negative index %ld", current);
+            goto done;
+        }
     }
+done:
     if (hashmap != NULL)
         hash_free(hashmap);
 }

--- a/storage/tradindexed/tdx-util.c
+++ b/storage/tradindexed/tdx-util.c
@@ -53,6 +53,7 @@ dump_index(const char *group)
         entry = tdx_index_entry(index, group);
         if (entry == NULL) {
             warn("cannot find group %s", group);
+            tdx_index_close(index);
             return;
         }
         tdx_index_print(group, entry, stdout);
@@ -77,11 +78,13 @@ dump_group_index(const char *group)
     entry = tdx_index_entry(index, group);
     if (entry == NULL) {
         warn("cannot find group %s in the index", group);
+        tdx_index_close(index);
         return;
     }
     data = tdx_data_open(index, group, entry);
     if (data == NULL) {
         warn("cannot open group %s", group);
+        tdx_index_close(index);
         return;
     }
     tdx_data_index_dump(data, stdout);
@@ -115,14 +118,15 @@ dump_overview(const char *group, ARTNUM low, ARTNUM high, bool overchan)
     entry = tdx_index_entry(index, group);
     if (entry == NULL) {
         warn("cannot find group %s", group);
+        tdx_index_close(index);
         return;
     }
     data = tdx_data_open(index, group, entry);
     if (data == NULL) {
         warn("cannot open group %s", group);
+        tdx_index_close(index);
         return;
     }
-    data->refcount++;
 
     if (low == 0)
         low = entry->low;
@@ -135,11 +139,14 @@ dump_overview(const char *group, ARTNUM low, ARTNUM high, bool overchan)
             puts("Article not found");
         else
             warn("cannot open search in %s: %lu - %lu", group, low, high);
+        tdx_data_close(data);
         tdx_index_close(index);
         return;
     }
     while (tdx_search(search, &article)) {
         if (overchan) {
+            if (article.overlen < 3)
+                continue;
             p = memchr(article.overview, '\t', article.overlen - 3);
             if (p == NULL)
                 continue;
@@ -149,6 +156,8 @@ dump_overview(const char *group, ARTNUM low, ARTNUM high, bool overchan)
                    (unsigned long) article.expires);
             fwrite(p, article.overlen - 2 - (p - article.overview), 1, stdout);
         } else {
+            if (article.overlen < 2)
+                continue;
             fwrite(article.overview, article.overlen - 2, 1, stdout);
             printf("\tArticle: %lu\tToken: %s", article.number,
                    TokenToText(article.token));

--- a/storage/tradspool/tradspool.c
+++ b/storage/tradspool/tradspool.c
@@ -1197,7 +1197,7 @@ tradspool_next(ARTHANDLE *article, const RETRTYPE amount)
         xrefhdr = wire_findheader(art->data, art->len, "Xref", true);
         if (xrefhdr != NULL) {
             if ((xrefs = CrackXref(xrefhdr, &numxrefs)) == NULL
-                || numxrefs == 0) {
+                || numxrefs < 2) {
                 art->len = 0;
             } else {
                 /* assumes first one is the original */

--- a/storage/tradspool/tradspool.c
+++ b/storage/tradspool/tradspool.c
@@ -813,6 +813,12 @@ OpenArticle(const char *path, RETRTYPE amount)
         close(fd);
         return NULL;
     }
+    if (sb.st_size < 0 || sb.st_size > UINT_MAX) {
+        SMseterror(SMERR_UNDEFINED, "article is too large");
+        free(art);
+        close(fd);
+        return NULL;
+    }
 
     art->arrived = sb.st_mtime;
 
@@ -859,7 +865,7 @@ OpenArticle(const char *path, RETRTYPE amount)
     } else {
         private->mmapped = false;
         private->artbase = xmalloc(private->artlen);
-        if (read(fd, private->artbase, private->artlen) < 0) {
+        if (xread(fd, private->artbase, private->artlen) < 0) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("tradspool: could not read article %s", path);
             free(private->artbase);
@@ -872,6 +878,7 @@ OpenArticle(const char *path, RETRTYPE amount)
         if (p == NULL || p == private->artbase) {
             SMseterror(SMERR_UNDEFINED, NULL);
             syswarn("tradspool: apparently corrupt article %s", path);
+            free(private->artbase);
             free(art->private);
             free(art);
             close(fd);

--- a/tests/lib/buffer-t.c
+++ b/tests/lib/buffer-t.c
@@ -72,7 +72,7 @@ main(void)
     ssize_t count;
     size_t offset;
 
-    plan(89);
+    plan(91);
 
     /* buffer_set, buffer_append, buffer_swap */
     buffer_set(&one, test_string1, sizeof(test_string1));
@@ -168,6 +168,10 @@ main(void)
     ok(buffer_find_string(three, "\r\n", 0, &offset),
        "finding the string on the whole buffer works");
     is_int(1023, offset, "and returns the correct location");
+    ok(!buffer_find_string(three, "\r\n", three->left + 1, &offset),
+       "search starting past the buffered data fails safely");
+    ok(!buffer_find_string(three, "", 0, &offset),
+       "searching for an empty string fails safely");
     three->used += 400;
     three->left -= 400;
     buffer_compact(three);

--- a/tests/lib/conffile-t.c
+++ b/tests/lib/conffile-t.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 
 #include "conffile.h"
+#include "inn/libinn.h"
 #include "inn/messages.h"
 #include "tap/basic.h"
 
@@ -20,12 +21,14 @@ static const char error[] = "test \"test\ntest\ntest";
 int
 main(void)
 {
+    char *array_config[2];
+    char *long_line;
     FILE *config;
     CONFFILE *parser;
     CONFTOKEN *token;
     unsigned int n, i;
 
-    test_init(16);
+    test_init(20);
 
     config = fopen(".testout", "w");
     if (config == NULL)
@@ -59,6 +62,36 @@ main(void)
     token = CONFgettoken(NULL, parser);
     ok(n++, token == NULL);
     CONFfclose(parser);
+
+    /* Array-backed input must stop before indexing past the array when a
+       quoted string continues at EOF. */
+    array_config[0] = (char *) "test \"unterminated";
+    parser = xcalloc(1, sizeof(CONFFILE));
+    parser->array = array_config;
+    parser->array_len = 1;
+    parser->filename = xstrdup("array");
+    token = CONFgettoken(NULL, parser);
+    ok(n++, token != NULL && strcmp(token->name, "test") == 0);
+    token = CONFgettoken(NULL, parser);
+    ok(n++, token == NULL);
+    CONFfclose(parser);
+
+    /* A continuation element is bounded by the space remaining in buf. */
+    long_line = xmalloc(BIG_BUFFER + 1);
+    memset(long_line, 'a', BIG_BUFFER);
+    long_line[BIG_BUFFER] = '\0';
+    array_config[0] = (char *) "test \"";
+    array_config[1] = long_line;
+    parser = xcalloc(1, sizeof(CONFFILE));
+    parser->array = array_config;
+    parser->array_len = 2;
+    parser->filename = xstrdup("array");
+    token = CONFgettoken(NULL, parser);
+    ok(n++, token != NULL && strcmp(token->name, "test") == 0);
+    token = CONFgettoken(NULL, parser);
+    ok(n++, token == NULL);
+    CONFfclose(parser);
+    free(long_line);
 
     unlink(".testout");
     return 0;

--- a/tests/lib/confparse-t.c
+++ b/tests/lib/confparse-t.c
@@ -358,7 +358,7 @@ main(void)
     int n;
     FILE *tmpconfig;
 
-    test_init(373);
+    test_init(376);
 
     if (access("../data/config/valid", F_OK) == 0) {
         if (chdir("../data") < 0) {
@@ -698,7 +698,32 @@ main(void)
     n = test_warnings_uint(n);
     n = test_warnings_real(n);
     n = test_warnings_string(n);
-    test_warnings_list(n);
+    n = test_warnings_list(n);
+
+    /* An escape at the last byte of a read buffer must pull in the escaped
+       character before the parser examines it. */
+    tmpconfig = fopen("config/tmp", "w");
+    if (tmpconfig == NULL)
+        sysdie("cannot create config/tmp");
+    fputs("parameter: \"", tmpconfig);
+    length = BUFSIZ - 2 - strlen("parameter: \"");
+    long_value = xcalloc(length + 2, 1);
+    memset(long_value, 'a', length);
+    long_value[length] = '\n';
+    while (length-- > 0)
+        fputc('a', tmpconfig);
+    fputs("\\n\"\n", tmpconfig);
+    fclose(tmpconfig);
+    group = config_parse_file("config/tmp");
+    ok(n++, group != NULL);
+    s_value = NULL;
+    ok(n++, group != NULL
+                && config_param_string(group, "parameter", &s_value));
+    ok_string(n++, long_value, s_value);
+    if (group != NULL)
+        config_free(group);
+    unlink("config/tmp");
+    free(long_value);
 
     return 0;
 }

--- a/tests/lib/hex-t.c
+++ b/tests/lib/hex-t.c
@@ -18,7 +18,7 @@ main(void)
     unsigned char dout[4];
     char tout[9];
 
-    test_init(16);
+    test_init(17);
 
     inn_encode_hex(d1, sizeof(d1), tout, sizeof(tout));
     ok_string(1, t1, tout);
@@ -39,23 +39,25 @@ main(void)
     ok_string(8, "0102B", tout);
     inn_encode_hex(d2, sizeof(d2), tout, 1);
     ok_string(9, "", tout);
+    inn_encode_hex(d2, SIZE_MAX / 2 + 1, tout, 3);
+    ok_string(10, "01", tout);
 
     inn_decode_hex(t1, dout, sizeof(dout));
-    ok(10, memcmp(d1, dout, sizeof(dout)) == 0);
+    ok(11, memcmp(d1, dout, sizeof(dout)) == 0);
     inn_decode_hex(t2, dout, sizeof(dout));
-    ok(11, memcmp(d2, dout, sizeof(dout)) == 0);
+    ok(12, memcmp(d2, dout, sizeof(dout)) == 0);
     inn_decode_hex(t3, dout, sizeof(dout));
-    ok(12, memcmp(d3, dout, sizeof(dout)) == 0);
+    ok(13, memcmp(d3, dout, sizeof(dout)) == 0);
     inn_decode_hex(t4, dout, sizeof(dout));
-    ok(13, memcmp(d2, dout, sizeof(dout)) == 0);
+    ok(14, memcmp(d2, dout, sizeof(dout)) == 0);
 
     inn_decode_hex(t2, dout, sizeof(dout));
     inn_decode_hex(t1, dout, 1);
-    ok(14, memcmp("", dout, 1) == 0);
-    ok(15, memcmp("\2\276\277", dout + 1, 3) == 0);
+    ok(15, memcmp("", dout, 1) == 0);
+    ok(16, memcmp("\2\276\277", dout + 1, 3) == 0);
     inn_decode_hex(t2, dout, sizeof(dout));
     inn_decode_hex(t1, dout, 0);
-    ok(16, memcmp(d2, dout, sizeof(dout)) == 0);
+    ok(17, memcmp(d2, dout, sizeof(dout)) == 0);
 
     return 0;
 }

--- a/tests/lib/wire-t.c
+++ b/tests/lib/wire-t.c
@@ -44,7 +44,7 @@ main(void)
     struct stat st;
     size_t wire_size, native_size, size;
 
-    test_init(58);
+    test_init(64);
 
     end = ta + sizeof(ta) - 1;
     p = end - 4;
@@ -137,6 +137,9 @@ main(void)
 
     free(article);
 
+    ok(37, wire_findheader("", 0, "X", true) == NULL);
+    ok(38, wire_findheader("X: \r\n", 5, "X", true) == NULL);
+
     /* Tests for wire to native conversion and vice versa. */
     wire = read_file("articles/wire-7", &st);
     wire_size = st.st_size;
@@ -144,13 +147,13 @@ main(void)
     native_size = st.st_size;
 
     article = wire_from_native(native, native_size, &size);
-    ok_int(37, wire_size, size);
-    ok(38, memcmp(wire, article, wire_size) == 0);
+    ok_int(39, wire_size, size);
+    ok(40, memcmp(wire, article, wire_size) == 0);
     free(article);
 
     article = wire_to_native(wire, wire_size, &size);
-    ok_int(39, native_size, size);
-    ok(40, memcmp(native, article, native_size) == 0);
+    ok_int(41, native_size, size);
+    ok(42, memcmp(native, article, native_size) == 0);
     free(article);
     free(wire);
     free(native);
@@ -159,47 +162,57 @@ main(void)
     wire = xstrdup("From: f@example.com\n\nSome body.\n");
     wire_size = strlen(wire);
     article = wire_to_native(wire, wire_size, &size);
-    ok_int(41, wire_size, size);
-    ok_string(42, wire, article);
+    ok_int(43, wire_size, size);
+    ok_string(44, wire, article);
     free(wire);
     free(article);
 
     /* An empty article. */
     article = wire_to_native("", 0, &size);
-    ok_int(43, 0, size);
-    ok_string(44, "", article);
-    free(article);
-    article = wire_to_native(".\r\n", 3, &size);
     ok_int(45, 0, size);
     ok_string(46, "", article);
+    free(article);
+    article = wire_to_native(".\r\n", 3, &size);
+    ok_int(47, 0, size);
+    ok_string(48, "", article);
     article = wire_from_native("", 0, &size);
-    ok_int(47, 3, size);
-    ok_string(48, ".\r\n", article);
+    ok_int(49, 3, size);
+    ok_string(50, ".\r\n", article);
     free(article);
 
     /* Nasty partial articles. */
     article = wire_to_native("T: f\r\n\r\n.\r", 10, &size);
-    ok_int(49, 8, size);
-    ok_string(50, "T: f\n\n.\r", article);
+    ok_int(51, 8, size);
+    ok_string(52, "T: f\n\n.\r", article);
     free(article);
     article = wire_to_native("T: f\r\n\r\n.", 9, &size);
-    ok_int(51, 7, size);
-    ok_string(52, "T: f\n\n.", article);
+    ok_int(53, 7, size);
+    ok_string(54, "T: f\n\n.", article);
     free(article);
     article = wire_to_native("..\r\n.\r\n", 7, &size);
-    ok_int(53, 2, size);
-    ok_string(54, ".\n", article);
+    ok_int(55, 2, size);
+    ok_string(56, ".\n", article);
     free(article);
 
     /* Articles containing nul. */
     article = wire_to_native("T: f\0\r\n\r\n..\r\n.\r\n", 16, &size);
-    ok_int(55, 9, size);
-    ok(56, memcmp("T: f\0\n\n.\n", article, 9) == 0);
+    ok_int(57, 9, size);
+    ok(58, memcmp("T: f\0\n\n.\n", article, 9) == 0);
     free(article);
     article = wire_from_native("T: f\0\n\n.\n", 9, &size);
-    ok_int(57, 16, size);
-    ok(58, memcmp("T: f\0\r\n\r\n..\r\n.\r\n", article, 16) == 0);
+    ok_int(59, 16, size);
+    ok(60, memcmp("T: f\0\r\n\r\n..\r\n.\r\n", article, 16) == 0);
     free(article);
+
+    /* wire_nextline takes an inclusive pointer to the final octet. */
+    p = "x";
+    ok(61, wire_nextline(p, p) == NULL);
+    p = "\r\n";
+    ok(62, wire_nextline(p, p + 1) == NULL);
+    p = "\r\nx";
+    ok(63, wire_nextline(p, p + 2) == p + 2);
+    p = "x\r\nx";
+    ok(64, wire_nextline(p, p + 3) == p + 3);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

This PR collects 23 robustness and file/data-integrity changes for the 2.8
development branch. These changes make older parsers, maintenance tools, and
storage backends fail safely when configuration, history, overview, or stored
article data is malformed or truncated.

The series contains no security-advisory patches or unrelated functional
changes.

## 2.7 backport recommendations

These recommendations use a conservative stable-branch policy. Backend-specific
“Yes” entries are recommended when that backend remains supported in 2.7.

| Commit | Backport to 2.7? | Reason |
|--------|------------------|--------|
| `05b94542d` | No | Broad defensive buffer-API changes, including an empty-search contract clarification, without a demonstrated ordinary 2.7 failure. |
| `68b62cf7f` | No | Protects hexadecimal encoding at impractically large input sizes; suitable for main but not necessary on stable. |
| `17b4cc6ce` | Yes | Rejects malformed local overview and expiration state before backend structures are used. |
| `94c630d96` | No | The previous track-log allocation was oversized rather than overflowing; this is cleanup. |
| `b0eae5b0b` | No | Guards fastrm growth near integer and allocation limits that are not operationally realistic. |
| `18fd92bbd` | No | This is a 2.8 release-note entry; 2.7 should receive a separately tailored release note if needed. |
| `533b9811b` | Yes | Prevents stale cached descriptors, double cleanup, and invalid placeholder teardown in timecaf. |
| `efcf21f56` | No | Hardens the offline ninpaths converter against malformed dump files; low stable-branch priority. |
| `ef6f6fb35` | No | Primarily defensive parsing of malformed overview Xref formatting, including a benign terminator read. |
| `8268287be` | Yes | Fixes sys2nf allocation for an ordinary input file lacking a trailing newline. |
| `b815d3b15` | Yes | Prevents malformed stored Xref records from being used without a group/article pair. |
| `0164188ef` | Yes | Fixes an actual configuration-parser boundary over-read for escaped characters. |
| `ce86b7c76` | Yes | Bounds array-backed configuration parsing and its continuation handling. |
| `75ce47c06` | Yes | Prevents truncated or corrupt history records from being decoded past their terminator. |
| `fbcf78a85` | Yes | Prevents invalid `expire.ctl` class values from indexing outside the class table. |
| `377f508d3` | No | Protects a private innd-to-innfeed command stream from a bare-LF framing condition not normally generated by innd. |
| `7d2d0c2c8` | Yes | Prevents zero- and one-element expire vectors from being written past their allocation. |
| `276808550` | Yes | Makes archive, history rebuilding, wire parsing, and reader retrieval tolerate short stored articles. |
| `8bf102494` | No | Avoids technically undefined pre-start pointer formation on empty strings, without a demonstrated practical failure. |
| `25e54db60` | No | Defensive check for short local innxmit batch pathnames; low stable-branch impact. |
| `d119fe8e1` | Yes | Recommended when buffindexed is supported; validates persistent blocks, chains, counts, and overview spans. |
| `646fa4052` | Yes | Recommended when tradindexed is supported; validates persistent structures and repairs search/data ownership. |
| `c7f56faf0` | Yes | Recommended for the affected storage methods; fixes incomplete reads, descriptor leaks, invalid spans, CAF cleanup, and iteration state. |

Useful backend backport groupings:

- timecaf: `533b9811b`, `276808550`, `c7f56faf0`
- buffindexed: `276808550`, `d119fe8e1`
- tradindexed: `276808550`, `646fa4052`
- CNFS, timehash, or tradspool retrieval: `276808550`, `c7f56faf0`
